### PR TITLE
[Infra] Debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,38 @@ project:
 opam install <path-to-local-fbdk-dist>
 ```
 
+Then `dune build`.
+
 ## Develop
 
-`dune utop` to start an interactive environment with DDE. `open
-Debugutils;;` to simplify calling helper functions such as `peu`.
+### utop
+
+`dune utop` to start an interactive environment with DDE.
+
+```ocaml
+open Debugutils;; (* to simplify calling utility functions such as `peu` *)
+
+Debugutils.is_debug_mode := true;; (* or *)
+is_debug_mode := true;; (* to print debug information from the
+evaluation. *)
+```
+
+### Binary
+
+`dune exec src/interpreter.exe` to run the interpreter.
+
+Optionally pass in the `--debug` flag to print debug information from the
+evaluation:
+
+```sh
+dune exec src/interpreter.exe -- --debug
+```
+
+Optionally pass in a file name to run the interpreter on the file:
+
+```sh
+dune exec src/interpreter.exe -- <path-to-file> --debug
+```
 
 ## Testing
 

--- a/build_scripts/debugutils.ml
+++ b/build_scripts/debugutils.ml
@@ -1,22 +1,22 @@
+[@@@coverage off]
+
+let is_debug_mode = ref false
 let eval = Fbdk.Interpreter.eval
 
 let parse s =
-  let lexbuf = Lexing.from_string (s^";;") in
+  let lexbuf = Lexing.from_string (s ^ ";;") in
   Fbdk.Parser.main Fbdk.Lexer.token lexbuf
-    
-let unparse e =
-  Format.asprintf "%a" Fbdk.Pp.pp_expr e
 
-let parse_eval s =
-  Fbdk.Interpreter.eval (parse s)
+let unparse e = Format.asprintf "%a" Fbdk.Pp.pp_expr e
+let parse_eval s = Fbdk.Interpreter.eval !is_debug_mode (parse s)
 
 let parse_eval_unparse s =
-  unparse @@ Fbdk.Interpreter.eval (parse s)
+  unparse @@ Fbdk.Interpreter.eval !is_debug_mode (parse s)
 
 let peu = parse_eval_unparse
 
 let parse_eval_print s =
-  Format.printf "==> %a\n" Fbdk.Pp.pp_expr 
-    (Fbdk.Interpreter.eval @@ parse s)
+  Format.printf "==> %a\n" Fbdk.Pp.pp_expr
+    (Fbdk.Interpreter.eval !is_debug_mode (parse s))
 
-let pp s = s |> parse |> unparse |> print_string |> print_newline;;
+let pp s = s |> parse |> unparse |> print_string |> print_newline

--- a/src/ddeinterp.ml
+++ b/src/ddeinterp.ml
@@ -202,16 +202,19 @@ let rec label_to_expr target_label e sigma seen =
           label )
   | Let (_, _, _, _) -> failwith "unreachable"
 
-let eval e =
+let eval is_debug_mode e =
   let e = transform_let e in
   let () = fill_my_fun e None in
   let label, sigma = eval_helper e [] in
-  (* print_endline "****** Label Table ******";
-     print_my_expr my_expr;
-     print_endline "****** Label Table ******\n";
-     print_endline "****** MyFun Table ******";
-     print_my_fun my_fun;
-     print_endline "****** MyFun Table ******\n"; *)
+
+  if is_debug_mode then (
+    print_endline "****** Label Table ******";
+    print_my_expr my_expr;
+    print_endline "****** Label Table ******\n";
+    print_endline "****** MyFun Table ******";
+    print_my_fun my_fun;
+    print_endline "****** MyFun Table ******\n");
+
   let e = label_to_expr label (get_expr label) sigma StringSet.empty in
   Hashtbl.reset my_expr;
   Hashtbl.reset my_fun;

--- a/src/ddetype.ml
+++ b/src/ddetype.ml
@@ -1,3 +1,5 @@
+[@@@coverage off]
+
 open Ddeast
 
 exception TypecheckerNotImplementedException

--- a/src/fbdk.mli
+++ b/src/fbdk.mli
@@ -54,7 +54,7 @@ module Pp : sig
 end
 
 module Interpreter : sig
-  val eval : Ast.expr -> Ast.expr
+  val eval : bool -> Ast.expr -> Ast.expr
 end
 
 module Options : sig

--- a/tests/utils.ml
+++ b/tests/utils.ml
@@ -19,7 +19,7 @@ let rec strip_label (e : Ddeast.expr) : Fbast.expr =
 let dde_eval s =
   Lexing.from_string s
   |> Ddeparser.main Ddelexer.token
-  |> Ddeinterp.eval |> strip_label
+  |> Ddeinterp.eval false |> strip_label
 
 let dde_parse s =
   s ^ ";;" |> Lexing.from_string |> Ddeparser.main Ddelexer.token |> strip_label


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Allow opting into debug mode for all methods of running the interpreter (utop, executables), which will print out label-expression and MyFun mappings for easier debugging. See README for details.

Test plan:

Try the commands in README.