### PR TITLE
[Tests] Benchmark lazy semantics

### DIFF
--- a/tests/dune
+++ b/tests/dune
@@ -1,4 +1,4 @@
 (test
  (name tests)
  (modules tests tests_subst tests_self utils)
- (libraries ounit2 dde fbdk.fb))
+ (libraries ounit2 dde fbdk.fb core_bench core_unix.command_unix))

--- a/tests/tests_self.ml
+++ b/tests/tests_self.ml
@@ -1,5 +1,6 @@
 open OUnit2
 open Utils
+open Core_bench
 
 let test_laziness _ =
   assert_equal
@@ -12,8 +13,23 @@ let test_laziness _ =
 let test_memoization _ =
   assert_equal (dde_eval (Tests_subst.dde_fib 100)) (dde_parse "5050")
 
+(* TODO: mutable vs immutable data structures *)
+(* Benchmark fibonacci to see that it's linear time as intermediate interpretation results are cached *)
+let fib_bench =
+  Command_unix.run
+    (Bench.make_command
+       [
+         Bench.Test.create ~name:"fib 25" (fun () ->
+             dde_eval (Tests_subst.dde_fib 100));
+         Bench.Test.create ~name:"fib 50" (fun () ->
+             dde_eval (Tests_subst.dde_fib 100));
+         Bench.Test.create ~name:"fib 75" (fun () ->
+             dde_eval (Tests_subst.dde_fib 100));
+         Bench.Test.create ~name:"fib 100" (fun () ->
+             dde_eval (Tests_subst.dde_fib 100));
+       ])
+
 let dde_self_tests =
   [ "Laziness" >:: test_laziness; "Memoization" >:: test_memoization ]
 
-(* TODO: benchmark running time with caching; Core; mutable vs immutable data structures *)
 let dde_self = "DDE against self" >::: dde_self_tests


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #9
* #8
* __->__ #7

This PR uses the `Core_bench` library from Jane Street to benchmark the
performance of DDE's lazy evaluation on Fibonacci. We see that the running
time is linear to the input instead of exponential, and thus confirms
the efficacy of memoization.

Test plan:

Run `dune test` and see something like the following. Note that Time/Run
is consistently in the 76-78ms range, which is far from increasing
exponentially as the input increases.

```
┌─────────┬──────────┬─────────┬──────────┬──────────┬────────────┐
│ Name    │ Time/Run │ mWd/Run │ mjWd/Run │ Prom/Run │ Percentage │
├─────────┼──────────┼─────────┼──────────┼──────────┼────────────┤
│ fib 25  │  76.42ms │ 41.99kw │  36.72kw │  27.00kw │     97.98% │
│ fib 50  │  78.00ms │ 41.99kw │  39.80kw │  26.95kw │    100.00% │
│ fib 75  │  77.04ms │ 41.99kw │  25.91kw │  25.91kw │     98.77% │
│ fib 100 │  76.70ms │ 41.99kw │  30.98kw │  25.84kw │     98.34% │
└─────────┴──────────┴─────────┴──────────┴──────────┴────────────┘
```