### PR TITLE
[Refactor][Tests] Optionally run benchmarks with `--bench`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,5 +46,12 @@ dune exec src/interpreter.exe -- <path-to-file> --debug
 
 ## Testing
 
-`dune test` to run the associated test suite. `bisect-ppx-report html` or
-`bisect-ppx-report summary` to view coverage.
+`dune test` to run the associated test suite *without* benchmarking.
+
+To also benchmark the DDE interpreter's performance, pass in the `--bench` flag:
+
+```sh
+dune exec -- ./tests/tests.exe --bench
+``` 
+
+`bisect-ppx-report html` or `bisect-ppx-report summary` to view coverage.

--- a/tests/benchmarks.ml
+++ b/tests/benchmarks.ml
@@ -1,0 +1,19 @@
+open Utils
+open Core_bench
+
+(* TODO: mutable vs immutable data structures *)
+(* TODO: use programs from FPSE early assignments *)
+(* Benchmark fibonacci to see that it's linear time as intermediate interpretation results are cached *)
+let fib_bench () =
+  Command_unix.run ~argv:[ "" ]
+    (Bench.make_command
+       [
+         Bench.Test.create ~name:"fib 25" (fun () ->
+             dde_eval (Tests_subst.dde_fib 25));
+         Bench.Test.create ~name:"fib 50" (fun () ->
+             dde_eval (Tests_subst.dde_fib 50));
+         Bench.Test.create ~name:"fib 75" (fun () ->
+             dde_eval (Tests_subst.dde_fib 75));
+         Bench.Test.create ~name:"fib 100" (fun () ->
+             dde_eval (Tests_subst.dde_fib 100));
+       ])

--- a/tests/dune
+++ b/tests/dune
@@ -1,4 +1,11 @@
 (test
  (name tests)
- (modules tests tests_subst tests_env tests_self utils)
- (libraries ounit2 dde fbdk.fb fbdk.fbenv core_bench core_unix.command_unix))
+ (modules tests tests_subst tests_env tests_self benchmarks utils)
+ (libraries
+  ounit2
+  dde
+  fbdk.fb
+  fbdk.fbenv
+  core_bench
+  core_unix.command_unix
+  core))

--- a/tests/tests.ml
+++ b/tests/tests.ml
@@ -4,4 +4,8 @@ let tests =
   "All tests"
   >::: [ Tests_subst.dde_subst; Tests_env.dde_env; Tests_self.dde_self ]
 
-let () = run_test_tt_main tests
+let () =
+  let bench = ref false in
+  Arg.parse [ ("--bench", Arg.Set bench, "run benchmarks") ] (fun _ -> ()) "";
+  if !bench then Benchmarks.fib_bench ();
+  run_test_tt_main tests

--- a/tests/tests_self.ml
+++ b/tests/tests_self.ml
@@ -1,6 +1,5 @@
 open OUnit2
 open Utils
-open Core_bench
 
 let test_laziness _ =
   assert_equal
@@ -12,22 +11,6 @@ let test_laziness _ =
 
 let test_memoization _ =
   assert_equal (dde_eval (Tests_subst.dde_fib 100)) (dde_parse "5050")
-
-(* TODO: mutable vs immutable data structures *)
-(* Benchmark fibonacci to see that it's linear time as intermediate interpretation results are cached *)
-let fib_bench =
-  Command_unix.run
-    (Bench.make_command
-       [
-         Bench.Test.create ~name:"fib 25" (fun () ->
-             dde_eval (Tests_subst.dde_fib 100));
-         Bench.Test.create ~name:"fib 50" (fun () ->
-             dde_eval (Tests_subst.dde_fib 100));
-         Bench.Test.create ~name:"fib 75" (fun () ->
-             dde_eval (Tests_subst.dde_fib 100));
-         Bench.Test.create ~name:"fib 100" (fun () ->
-             dde_eval (Tests_subst.dde_fib 100));
-       ])
 
 let dde_self_tests =
   [ "Laziness" >:: test_laziness; "Memoization" >:: test_memoization ]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

This PR adds a `--bench` commandline flag to conditionally run the benchmarks
for the DDE interpreter, saving time if we only want to run unit tests.

This PR also fixes the benchmarks to truly run the interpreter on fibonnaci
programs of *different* inputs. The result of the benchmarks is consistent
with the expected linear time complexity of the interpreter when run on
exponential time algorithms.

Test plan:

`dune exec -- ./tests/tests.exe --bench` to run both the benchmarks and unit
tests. The running time of interpretation increases linearly against inputs to
functions and all tests pass.