### PR TITLE
[Interp] Implement new semantics

### DIFF
--- a/src/ddeast.ml
+++ b/src/ddeast.ml
@@ -3,43 +3,26 @@ exception Unreachable
 type ident = Ident of string
 [@@coverage off] [@@deriving show { with_path = false }]
 
-type expr =
-  | Int of int
-  | Var of ident
-  | Bool of bool
-  | Function of ident * lexpr
-  | Appl of lexpr * lexpr
-  | Plus of lexpr * lexpr
-  | Minus of lexpr * lexpr
-  | Equal of lexpr * lexpr
-  | And of lexpr * lexpr
-  | Or of lexpr * lexpr
-  | Not of lexpr
-  | If of lexpr * lexpr * lexpr
-  | Let of ident * lexpr * lexpr
+type value = Int of int | Bool of bool | Function of ident * expr * int
 
-and lexpr = expr * int [@@deriving show { with_path = false }]
-
-(* type expr =
-     | Int of int * int
-     | Var of ident * int
-     | Bool of bool * int
-     | Function of ident * expr * int
-     | Appl of expr * expr * int
-     | Plus of expr * expr * int
-     | Minus of expr * expr * int
-     | Equal of expr * expr * int
-     | And of expr * expr * int
-     | Or of expr * expr * int
-     | Not of expr * int
-     | If of expr * expr * expr * int
-     | Let of ident * expr * expr * int
-   [@@coverage off] [@@deriving show { with_path = false }] *)
+and expr =
+  | Value of value
+  | Var of ident * int
+  | Appl of expr * expr * int
+  | Plus of expr * expr * int
+  | Minus of expr * expr * int
+  | Equal of expr * expr * int
+  | And of expr * expr * int
+  | Or of expr * expr * int
+  | Not of expr * int
+  | If of expr * expr * expr * int
+  | Let of ident * expr * expr * int
+[@@deriving show { with_path = false }]
 
 type fbtype = TArrow of fbtype * fbtype | TVar of string
 [@@coverage off] [@@deriving show { with_path = false }]
 
-let my_expr : (int, lexpr) Hashtbl.t = Hashtbl.create 10000
+let my_expr = Hashtbl.create 10000
 let my_fun = Hashtbl.create 10000
 let get_expr label = Hashtbl.find my_expr label
 let add_expr label e = Hashtbl.replace my_expr label e
@@ -48,44 +31,47 @@ let get_outer_scope label = Hashtbl.find my_fun label
 let add_outer_scope label outer =
   if Option.is_some outer then Hashtbl.replace my_fun label @@ Option.get outer
 
-let rec fill_my_fun e outer =
+let rec fill_my_fun (e : expr) outer =
   match e with
-  | Int _, label | Bool _, label | Var _, label -> add_outer_scope label outer
-  | Function (_, e'), label ->
-      add_outer_scope label outer;
-      fill_my_fun e' (Some e)
-  | Appl (e1, e2), label ->
-      add_outer_scope label outer;
+  | Value v -> (
+      match v with
+      | Int _ -> ()
+      | Bool _ -> ()
+      | Function (i, e', l) ->
+          add_outer_scope l outer;
+          fill_my_fun e' (Some e))
+  | Var (_, l) -> add_outer_scope l outer
+  | Appl (e1, e2, l) ->
+      add_outer_scope l outer;
       fill_my_fun e1 outer;
       fill_my_fun e2 outer
-  | Plus (e1, e2), label
-  | Minus (e1, e2), label
-  | Equal (e1, e2), label
-  | And (e1, e2), label
-  | Or (e1, e2), label ->
-      add_outer_scope label outer;
+  | Plus (e1, e2, l)
+  | Minus (e1, e2, l)
+  | Equal (e1, e2, l)
+  | And (e1, e2, l)
+  | Or (e1, e2, l) ->
+      add_outer_scope l outer;
       fill_my_fun e1 outer;
       fill_my_fun e2 outer
-  | Not e, label ->
-      add_outer_scope label outer;
+  | Not (e, l) ->
+      add_outer_scope l outer;
       fill_my_fun e outer
-  | If (e1, e2, e3), label ->
-      add_outer_scope label outer;
+  | If (e1, e2, e3, l) ->
+      add_outer_scope l outer;
       fill_my_fun e1 outer;
       fill_my_fun e2 outer;
       fill_my_fun e3 outer
-  | Let (_, _, _), _ -> raise Unreachable [@coverage off]
+  | Let (_, _, _, _) -> raise Unreachable [@coverage off]
 
 let print_my_expr tbl =
-  Hashtbl.iter (fun x y -> Printf.printf "%d -> %s\n" x (show_lexpr y)) tbl
+  Hashtbl.iter (fun x y -> Printf.printf "%d -> %s\n" x (show_expr y)) tbl
   [@@coverage off]
 
 let print_my_fun tbl =
-  Hashtbl.iter (fun x y -> Printf.printf "%d -> %s\n" x (show_lexpr y)) tbl
+  Hashtbl.iter (fun x y -> Printf.printf "%d -> %s\n" x (show_expr y)) tbl
   [@@coverage off]
 
 let next_label = ref 0
-let make_lexpr e label : lexpr = (e, label)
 
 let get_next_label () =
   let l = !next_label in
@@ -94,78 +80,78 @@ let get_next_label () =
 
 let build_labeled_int i =
   let label = get_next_label () in
-  let labeled_int = make_lexpr (Int i) label in
+  let labeled_int = Value (Int i) in
   add_expr label labeled_int;
   labeled_int
 
 let build_labeled_bool b =
   let label = get_next_label () in
-  let labeled_bool = make_lexpr (Bool b) label in
+  let labeled_bool = Value (Bool b) in
   add_expr label labeled_bool;
   labeled_bool
 
 let build_labeled_function ident e =
   let label = get_next_label () in
-  let labeled_function = make_lexpr (Function (ident, e)) label in
+  let labeled_function = Value (Function (ident, e, label)) in
   add_expr label labeled_function;
   labeled_function
 
 let build_labeled_appl e1 e2 =
   let label = get_next_label () in
-  let labeled_appl = make_lexpr (Appl (e1, e2)) label in
+  let labeled_appl = Appl (e1, e2, label) in
   add_expr label labeled_appl;
   labeled_appl
 
 let build_labeled_var ident =
   let label = get_next_label () in
-  let labeled_var = make_lexpr (Var ident) label in
+  let labeled_var = Var (ident, label) in
   add_expr label labeled_var;
   labeled_var
 
 let build_labeled_plus e1 e2 =
   let label = get_next_label () in
-  let labeled_plus = make_lexpr (Plus (e1, e2)) label in
+  let labeled_plus = Plus (e1, e2, label) in
   add_expr label labeled_plus;
   labeled_plus
 
 let build_labeled_minus e1 e2 =
   let label = get_next_label () in
-  let labeled_minus = make_lexpr (Minus (e1, e2)) label in
+  let labeled_minus = Minus (e1, e2, label) in
   add_expr label labeled_minus;
   labeled_minus
 
 let build_labeled_equal e1 e2 =
   let label = get_next_label () in
-  let labeled_equal = make_lexpr (Equal (e1, e2)) label in
+  let labeled_equal = Equal (e1, e2, label) in
   add_expr label labeled_equal;
   labeled_equal
 
 let build_labeled_and e1 e2 =
   let label = get_next_label () in
-  let labeled_and = make_lexpr (And (e1, e2)) label in
+  let labeled_and = And (e1, e2, label) in
   add_expr label labeled_and;
   labeled_and
 
 let build_labeled_or e1 e2 =
   let label = get_next_label () in
-  let labeled_or = make_lexpr (Or (e1, e2)) label in
+  let labeled_or = Or (e1, e2, label) in
   add_expr label labeled_or;
   labeled_or
 
 let build_labeled_not e =
   let label = get_next_label () in
-  let labeled_not = make_lexpr (Not e) label in
+  let labeled_not = Not (e, label) in
   add_expr label labeled_not;
   labeled_not
 
 let build_labeled_if e1 e2 e3 =
   let label = get_next_label () in
-  let labeled_if = make_lexpr (If (e1, e2, e3)) label in
+  let labeled_if = If (e1, e2, e3, label) in
   add_expr label labeled_if;
   labeled_if
 
 let build_labeled_let ident e1 e2 =
   let label = get_next_label () in
-  let labeled_let = make_lexpr (Let (ident, e1, e2)) label in
+  let labeled_let = Let (ident, e1, e2, label) in
   add_expr label labeled_let;
   labeled_let

--- a/src/ddeparser.mly
+++ b/src/ddeparser.mly
@@ -45,7 +45,7 @@ open Ddeast;;
  * The entry point.
  */
 %start main
-%type <Ddeast.lexpr> main
+%type <Ddeast.expr> main
 
 %%
 

--- a/src/ddepp.ml
+++ b/src/ddepp.ml
@@ -1,44 +1,57 @@
 [@@@coverage off]
 
 open Ddeast
+open Ddeinterp
 
 let ff = Format.fprintf
 
 let paren_if cond pp fmt e =
   if cond e then ff fmt "(%a)" pp e else ff fmt "%a" pp e
 
-let is_compound_expr = function Var _, _ -> false | _, _ -> true
+let is_compound_expr = function Var _ -> false | _ -> true
 
-let rec pp_lexpr fmt (le : lexpr) =
-  let e, label = le in
+let rec pp_expr fmt (e : expr) =
   match e with
-  | Int x -> ff fmt "(%d)^%d" x label
-  | Var (Ident x) -> ff fmt "(%s)^%d" x label
-  | Bool b -> ff fmt "(%b)^%d" b label
-  | Function (Ident i, x) ->
-      ff fmt "(@[<hv>function %s ->@;<1 4>%a@])^%d" i pp_lexpr x label
-  | Appl (e1, e2) ->
+  | Value value -> (
+      match value with
+      | Int i -> ff fmt "%d" i
+      | Bool b -> ff fmt "%b" b
+      | Function (Ident i, x, l) ->
+          ff fmt "(@[<hv>function %s ->@;<1 4>%a@])^%d" i pp_expr x l)
+  | Var (Ident x, l) -> ff fmt "(%s)^%d" x l
+  | Appl (e1, e2, l) ->
       let is_compound_exprL = function
-        | Appl _, _ -> false
+        | Appl _ -> false
         | other -> is_compound_expr other
       in
       ff fmt "(%a %a)^%d"
-        (paren_if is_compound_exprL pp_lexpr)
+        (paren_if is_compound_exprL pp_expr)
         e1
-        (paren_if is_compound_expr pp_lexpr)
-        e2 label
-  | Plus (e1, e2) -> ff fmt "(%a + %a)^%d" pp_lexpr e1 pp_lexpr e2 label
-  | Minus (e1, e2) -> ff fmt "(%a + %a)^%d" pp_lexpr e1 pp_lexpr e2 label
-  | Equal (e1, e2) -> ff fmt "(%a = %a)^%d" pp_lexpr e1 pp_lexpr e2 label
-  | And (e1, e2) -> ff fmt "(%a and %a)^%d" pp_lexpr e1 pp_lexpr e2 label
-  | Or (e1, e2) -> ff fmt "(%a and %a)^%d" pp_lexpr e1 pp_lexpr e2 label
-  | Not e1 -> ff fmt "(not %a)^%d" pp_lexpr e1 label
-  | If (e1, e2, e3) ->
-      ff fmt "(@[<hv>if %a then@;<1 4>%a@;<1 0>else@;<1 4>%a@])^%d" pp_lexpr e1
-        pp_lexpr e2 pp_lexpr e3 label
-  | Let (Ident i, e1, e2) ->
-      ff fmt "(@[<hv>let %s =@;<1 4>%a@;<1 0>In@;<1 4>%a@])^%d" i pp_lexpr e1
-        pp_lexpr e2 label
+        (paren_if is_compound_expr pp_expr)
+        e2 l
+  | Plus (e1, e2, l) -> ff fmt "(%a + %a)^%d" pp_expr e1 pp_expr e2 l
+  | Minus (e1, e2, l) -> ff fmt "(%a + %a)^%d" pp_expr e1 pp_expr e2 l
+  | Equal (e1, e2, l) -> ff fmt "(%a = %a)^%d" pp_expr e1 pp_expr e2 l
+  | And (e1, e2, l) -> ff fmt "(%a and %a)^%d" pp_expr e1 pp_expr e2 l
+  | Or (e1, e2, l) -> ff fmt "(%a and %a)^%d" pp_expr e1 pp_expr e2 l
+  | Not (e1, l) -> ff fmt "(not %a)^%d" pp_expr e1 l
+  | If (e1, e2, e3, l) ->
+      ff fmt "(@[<hv>if %a then@;<1 4>%a@;<1 0>else@;<1 4>%a@])^%d" pp_expr e1
+        pp_expr e2 pp_expr e3 l
+  | Let (Ident i, e1, e2, l) ->
+      ff fmt "(@[<hv>let %s =@;<1 4>%a@;<1 0>In@;<1 4>%a@])^%d" i pp_expr e1
+        pp_expr e2 l
+
+let rec pp_result_value fmt (v : result_value) =
+  match v with
+  | IntResult x -> ff fmt "%d" x
+  | BoolResult b -> ff fmt "%b" b
+  | FunctionResult { f; l; sigma } -> (
+      match f with
+      | Function (Ident i, le, l) ->
+          ff fmt "(@[<hv>function %s ->@;<1 4>%a@])^%d" i pp_expr le l
+      | _ -> raise Unreachable)
+  | OpResult op -> raise Unreachable
 
 let rec pp_fbtype fmt = function
   | TArrow (t1, t2) ->
@@ -46,5 +59,5 @@ let rec pp_fbtype fmt = function
       ff fmt "%a -> %a" (paren_if is_arrow pp_fbtype) t1 pp_fbtype t2
   | TVar s -> ff fmt "%s" s
 
-let show_lexpr (le : lexpr) = Format.asprintf "%a" pp_lexpr le
+let show_expr (le : expr) = Format.asprintf "%a" pp_expr le
 let show_fbtype t = Format.asprintf "%a" pp_fbtype t

--- a/src/debugutils.ml
+++ b/src/debugutils.ml
@@ -7,7 +7,7 @@ let parse s =
   let lexbuf = Lexing.from_string (s ^ ";;") in
   Fbdk.Parser.main Fbdk.Lexer.token lexbuf
 
-let unparse e = Format.asprintf "%a" Fbdk.Pp.pp_lexpr e
+let unparse v = Format.asprintf "%a" Fbdk.Pp.pp_result_value v
 let parse_eval s = Fbdk.Interpreter.eval !is_debug_mode (parse s)
 
 let parse_eval_unparse s =
@@ -16,7 +16,7 @@ let parse_eval_unparse s =
 let peu = parse_eval_unparse
 
 let parse_eval_print s =
-  Format.printf "==> %a\n" Fbdk.Pp.pp_lexpr
+  Format.printf "==> %a\n" Fbdk.Pp.pp_result_value
     (Fbdk.Interpreter.eval !is_debug_mode (parse s))
 
-let pp s = s |> parse |> unparse |> print_string |> print_newline
+(* let pp s = s |> parse |> unparse |> print_string |> print_newline *)

--- a/src/fbdk.mli
+++ b/src/fbdk.mli
@@ -3,27 +3,25 @@ val name : string
 module Ast : sig
   type ident = Ddeast.ident = Ident of string
 
-  type lexpr = expr * int
+  type value = Int of int | Bool of bool | Function of ident * expr * int
 
   and expr =
-    | Int of int
-    | Var of ident
-    | Bool of bool
-    | Function of ident * lexpr
-    | Appl of lexpr * lexpr
-    | Plus of lexpr * lexpr
-    | Minus of lexpr * lexpr
-    | Equal of lexpr * lexpr
-    | And of lexpr * lexpr
-    | Or of lexpr * lexpr
-    | Not of lexpr
-    | If of lexpr * lexpr * lexpr
-    | Let of ident * lexpr * lexpr
+    | Value of value
+    | Var of ident * int
+    | Appl of expr * expr * int
+    | Plus of expr * expr * int
+    | Minus of expr * expr * int
+    | Equal of expr * expr * int
+    | And of expr * expr * int
+    | Or of expr * expr * int
+    | Not of expr * int
+    | If of expr * expr * expr * int
+    | Let of ident * expr * expr * int
 
   type fbtype = Ddeast.fbtype = TArrow of fbtype * fbtype | TVar of string
 
-  val show_lexpr : lexpr -> string
-  val pp_lexpr : Format.formatter -> lexpr -> unit [@@ocaml.toplevel_printer]
+  val show_expr : expr -> string
+  val pp_expr : Format.formatter -> expr -> unit [@@ocaml.toplevel_printer]
   val show_fbtype : fbtype -> string
   val pp_fbtype : Format.formatter -> fbtype -> unit [@@ocaml.toplevel_printer]
 end
@@ -31,7 +29,7 @@ end
 module Parser : sig
   type token
 
-  val main : (Lexing.lexbuf -> token) -> Lexing.lexbuf -> Ast.lexpr
+  val main : (Lexing.lexbuf -> token) -> Lexing.lexbuf -> Ast.expr
 end
 
 module Lexer : sig
@@ -44,19 +42,34 @@ module Typechecker : sig
   (* Typechecker module's typecheck function. *)
   exception TypecheckerNotImplementedException
 
-  val typecheck : Ast.lexpr -> Ast.fbtype
+  val typecheck : Ast.expr -> Ast.fbtype
   val typecheck_default_enabled : bool
 end
 
-module Pp : sig
-  val show_lexpr : Ast.lexpr -> string
-  val pp_lexpr : Format.formatter -> Ast.lexpr -> unit
-  val show_fbtype : Ast.fbtype -> string
-  val pp_fbtype : Format.formatter -> Ast.fbtype -> unit
+module Interpreter : sig
+  type op_result_value =
+    | Plus of result_value * result_value
+    | Minus of result_value * result_value
+    | Equal of result_value * result_value
+    | And of result_value * result_value
+    | Or of result_value * result_value
+    | Not of result_value
+
+  and result_value =
+    | FunctionResult of { f : Ast.value; l : int; sigma : int list }
+    | IntResult of int
+    | BoolResult of bool
+    | OpResult of op_result_value
+
+  val eval : bool -> Ast.expr -> result_value
 end
 
-module Interpreter : sig
-  val eval : bool -> Ast.lexpr -> Ast.lexpr
+module Pp : sig
+  val show_expr : Ast.expr -> string
+  val pp_expr : Format.formatter -> Ast.expr -> unit
+  val pp_result_value : Format.formatter -> Interpreter.result_value -> unit
+  val show_fbtype : Ast.fbtype -> string
+  val pp_fbtype : Format.formatter -> Ast.fbtype -> unit
 end
 
 module Options : sig

--- a/src/interpreter.ml
+++ b/src/interpreter.ml
@@ -42,7 +42,7 @@ let toplevel_loop typechecking_enabled show_types is_debug_mode =
   let safe_interpret_and_print ast =
     try
       let result = Fbdk.Interpreter.eval is_debug_mode ast in
-      Format.printf "==> %a\n" Fbdk.Pp.pp_lexpr result
+      Format.printf "==> %a\n" Fbdk.Pp.pp_result_value result
     with ex -> print_exception ex
   in
   Format.printf "\t%s version %s\t" Fbdk.name Fbdk.Version.version;
@@ -65,7 +65,7 @@ let run_file filename is_debug_mode =
   let lexbuf = Lexing.from_channel fin in
   let ast = Fbdk.Parser.main Fbdk.Lexer.token lexbuf in
   let result = Fbdk.Interpreter.eval is_debug_mode ast in
-  Format.printf "%a\n" Fbdk.Pp.pp_lexpr result;
+  Format.printf "%a\n" Fbdk.Pp.pp_result_value result;
   Format.print_flush ()
 
 let print_version () =

--- a/tests/benchmarks.ml
+++ b/tests/benchmarks.ml
@@ -9,11 +9,11 @@ let fib_bench () =
     (Bench.make_command
        [
          Bench.Test.create ~name:"fib 25" (fun () ->
-             dde_eval (Tests_subst.dde_fib 25));
+             dde_eval_fb (Tests_subst.dde_fib 25));
          Bench.Test.create ~name:"fib 50" (fun () ->
-             dde_eval (Tests_subst.dde_fib 50));
+             dde_eval_fb (Tests_subst.dde_fib 50));
          Bench.Test.create ~name:"fib 75" (fun () ->
-             dde_eval (Tests_subst.dde_fib 75));
+             dde_eval_fb (Tests_subst.dde_fib 75));
          Bench.Test.create ~name:"fib 100" (fun () ->
-             dde_eval (Tests_subst.dde_fib 100));
+             dde_eval_fb (Tests_subst.dde_fib 100));
        ])

--- a/tests/tests_env.ml
+++ b/tests/tests_env.ml
@@ -2,67 +2,71 @@ open OUnit2
 open Utils
 
 let test_numerical _ =
-  assert_equal (dde_eval_env "1;;") (fbenv_eval "1;;");
-  assert_equal (dde_eval_env "-2;;") (fbenv_eval "-2;;");
-  assert_equal (dde_eval_env "1 + 2;;") (fbenv_eval "1 + 2;;");
-  assert_equal (dde_eval_env "1 - 2;;") (fbenv_eval "1 - 2;;")
+  assert_equal (dde_eval_fbenv "1;;") (fbenv_eval "1;;");
+  assert_equal (dde_eval_fbenv "-2;;") (fbenv_eval "-2;;");
+  assert_equal (dde_eval_fbenv "1 + 2;;") (fbenv_eval "1 + 2;;");
+  assert_equal (dde_eval_fbenv "1 - 2;;") (fbenv_eval "1 - 2;;")
 
 let test_logical _ =
-  assert_equal (dde_eval_env "true;;") (fbenv_eval "True;;");
-  assert_equal (dde_eval_env "false;;") (fbenv_eval "False;;");
-  assert_equal (dde_eval_env "not true;;") (fbenv_eval "Not True;;");
-  assert_equal (dde_eval_env "false or true;;") (fbenv_eval "False Or True;;");
-  assert_equal (dde_eval_env "true and false;;") (fbenv_eval "True And False;;")
+  assert_equal (dde_eval_fbenv "true;;") (fbenv_eval "True;;");
+  assert_equal (dde_eval_fbenv "false;;") (fbenv_eval "False;;");
+  assert_equal (dde_eval_fbenv "not true;;") (fbenv_eval "Not True;;");
+  assert_equal (dde_eval_fbenv "false or true;;") (fbenv_eval "False Or True;;");
+  assert_equal
+    (dde_eval_fbenv "true and false;;")
+    (fbenv_eval "True And False;;")
 
 let test_relational _ =
-  assert_equal (dde_eval_env "1 = 1;;") (fbenv_eval "1 = 1;;");
-  assert_equal (dde_eval_env "-1 = 2;;") (fbenv_eval "-1 = 2;;")
+  assert_equal (dde_eval_fbenv "1 = 1;;") (fbenv_eval "1 = 1;;");
+  assert_equal (dde_eval_fbenv "-1 = 2;;") (fbenv_eval "-1 = 2;;")
 
 let test_let _ =
   assert_equal
-    (dde_eval_env "let y = false in y;;")
+    (dde_eval_fbenv "let y = false in y;;")
     (fbenv_eval "Let y = False In y;;");
   assert_equal
-    (dde_eval_env "let x = 5 in let y = 10 in x + y = 15;;")
+    (dde_eval_fbenv "let x = 5 in let y = 10 in x + y = 15;;")
     (fbenv_eval "Let x = 5 In Let y = 10 In x + y = 15;;")
 
 let test_if _ =
   assert_equal
-    (dde_eval_env "if false then 0 else 1;;")
+    (dde_eval_fbenv "if false then 0 else 1;;")
     (fbenv_eval "If False Then 0 Else 1;;");
   assert_equal
-    (dde_eval_env "let x = 1 in if x + 2 = 3 then x - 1 else x + 1;;")
+    (dde_eval_fbenv "let x = 1 in if x + 2 = 3 then x - 1 else x + 1;;")
     (fbenv_eval "Let x = 1 In If x + 2 = 3 Then x - 1 Else x + 1;;")
 
 let test_function _ =
-  assert_equal (dde_eval_env "fun x -> x;;") (fbenv_eval "Fun x -> x;;");
-  assert_equal (dde_eval_env "fun x -> 1;;") (fbenv_eval "Fun x -> 1;;");
+  assert_equal (dde_eval_fbenv "fun x -> x;;") (fbenv_eval "Fun x -> x;;");
+  assert_equal (dde_eval_fbenv "fun x -> 1;;") (fbenv_eval "Fun x -> 1;;");
   assert_equal
-    (dde_eval_env "fun x -> fun y -> fun z -> y;;")
+    (dde_eval_fbenv "fun x -> fun y -> fun z -> y;;")
     (fbenv_eval "Fun x -> Fun y -> Fun z -> y;;")
 
 let test_basic_application _ =
-  assert_equal (dde_eval_env "(fun x -> x) 1;;") (fbenv_eval "(Fun x -> x) 1;;");
   assert_equal
-    (dde_eval_env "(fun x -> 1) (-2);;")
+    (dde_eval_fbenv "(fun x -> x) 1;;")
+    (fbenv_eval "(Fun x -> x) 1;;");
+  assert_equal
+    (dde_eval_fbenv "(fun x -> 1) (-2);;")
     (fbenv_eval "(Fun x -> 1) (-2);;");
   assert_equal
-    (dde_eval_env "((fun x -> fun y -> y) 1) 2;;")
+    (dde_eval_fbenv "((fun x -> fun y -> y) 1) 2;;")
     (fbenv_eval "((Fun x -> Fun y -> y) 1) 2;;")
 
 let test_involved_application _ =
   assert_equal
-    (dde_eval_env "((fun x -> fun y -> x) 1) 2;;")
+    (dde_eval_fbenv "((fun x -> fun y -> x) 1) 2;;")
     (fbenv_eval "((Fun x -> Fun y -> x) 1) 2;;");
   assert_equal
-    (dde_eval_env "((fun x -> fun y -> y x) 1) (fun x -> x + 10);;")
+    (dde_eval_fbenv "((fun x -> fun y -> y x) 1) (fun x -> x + 10);;")
     (fbenv_eval "((Fun x -> Fun y -> y x) 1) (Fun x -> x + 10);;");
   assert_equal
-    (dde_eval_env "(fun x -> (fun y -> (fun z -> z + 1) y) (x + 2)) 6;;")
+    (dde_eval_fbenv "(fun x -> (fun y -> (fun z -> z + 1) y) (x + 2)) 6;;")
     (fbenv_eval "(Fun x -> (Fun y -> (Fun z -> z + 1) y) (x + 2)) 6;;");
   (* call-by-name semantics *)
   assert_unequal
-    (dde_eval_env "(fun x -> fun y -> x) (1 + 2);;")
+    (dde_eval_fbenv "(fun x -> fun y -> x) (1 + 2);;")
     (fbenv_eval "(Fun x -> Fun y -> x) (1 + 2);;")
 
 let dde_ycomb =
@@ -87,13 +91,13 @@ let fb_fib x =
 
 let test_ycomb _ =
   assert_equal
-    (dde_eval_env
+    (dde_eval_fbenv
        "let summate0 = fun self -> fun arg -> if arg = 0 then 0 else arg + \
         self self (arg - 1) in summate0 summate0 5;;")
     (fbenv_eval
        "Let summate0 = Fun self -> Fun arg -> If arg = 0 Then 0 Else arg + \
         self self (arg - 1) In summate0 summate0 5;;");
-  assert_equal (dde_eval_env @@ dde_fib 5) (fbenv_eval @@ fb_fib 5)
+  assert_equal (dde_eval_fbenv @@ dde_fib 5) (fbenv_eval @@ fb_fib 5)
 
 let dde_env_tests =
   [

--- a/tests/tests_self.ml
+++ b/tests/tests_self.ml
@@ -3,14 +3,14 @@ open Utils
 
 let test_laziness _ =
   assert_equal
-    (dde_eval "(fun x -> fun y -> x) ((fun z -> z + 1) (1 + 2 + 3));;")
-    (dde_parse "fun y -> (fun z -> z + 1) (1 + 2 + 3)");
+    (dde_eval_fb "(fun x -> fun y -> x) ((fun z -> z + 1) (1 + 2 + 3));;")
+    (dde_parse "fun y -> 7");
   assert_equal
-    (dde_eval "(fun x -> fun y -> x) (if true then 1 else 0);;")
-    (dde_parse "fun y -> if true then 1 else 0")
+    (dde_eval_fb "(fun x -> fun y -> x) (if true then 1 else 0);;")
+    (dde_parse "fun y -> 1")
 
 let test_memoization _ =
-  assert_equal (dde_eval (Tests_subst.dde_fib 100)) (dde_parse "5050")
+  assert_equal (dde_eval_fb (Tests_subst.dde_fib 100)) (dde_parse "5050")
 
 let dde_self_tests =
   [ "Laziness" >:: test_laziness; "Memoization" >:: test_memoization ]

--- a/tests/tests_subst.ml
+++ b/tests/tests_subst.ml
@@ -2,65 +2,66 @@ open OUnit2
 open Utils
 
 let test_numerical _ =
-  assert_equal (dde_eval "1;;") (fb_eval "1;;");
-  assert_equal (dde_eval "-2;;") (fb_eval "-2;;");
-  assert_equal (dde_eval "1 + 2;;") (fb_eval "1 + 2;;");
-  assert_equal (dde_eval "1 - 2;;") (fb_eval "1 - 2;;")
+  assert_equal (dde_eval_fb "1;;") (fb_eval "1;;");
+  assert_equal (dde_eval_fb "-2;;") (fb_eval "-2;;");
+  assert_equal (dde_eval_fb "1 + 2;;") (fb_eval "1 + 2;;");
+  assert_equal (dde_eval_fb "1 - 2;;") (fb_eval "1 - 2;;")
 
 let test_logical _ =
-  assert_equal (dde_eval "true;;") (fb_eval "True;;");
-  assert_equal (dde_eval "false;;") (fb_eval "False;;");
-  assert_equal (dde_eval "not true;;") (fb_eval "Not True;;");
-  assert_equal (dde_eval "false or true;;") (fb_eval "False Or True;;");
-  assert_equal (dde_eval "true and false;;") (fb_eval "True And False;;")
+  assert_equal (dde_eval_fb "true;;") (fb_eval "True;;");
+  assert_equal (dde_eval_fb "false;;") (fb_eval "False;;");
+  assert_equal (dde_eval_fb "not true;;") (fb_eval "Not True;;");
+  assert_equal (dde_eval_fb "false or true;;") (fb_eval "False Or True;;");
+  assert_equal (dde_eval_fb "true and false;;") (fb_eval "True And False;;")
 
 let test_relational _ =
-  assert_equal (dde_eval "1 = 1;;") (fb_eval "1 = 1;;");
-  assert_equal (dde_eval "-1 = 2;;") (fb_eval "-1 = 2;;")
+  assert_equal (dde_eval_fb "1 = 1;;") (fb_eval "1 = 1;;");
+  assert_equal (dde_eval_fb "-1 = 2;;") (fb_eval "-1 = 2;;")
 
 let test_let _ =
   assert_equal
-    (dde_eval "let y = false in y;;")
+    (dde_eval_fb "let y = false in y;;")
     (fb_eval "Let y = False In y;;");
   assert_equal
-    (dde_eval "let x = 5 in let y = 10 in x + y = 15;;")
+    (dde_eval_fb "let x = 5 in let y = 10 in x + y = 15;;")
     (fb_eval "Let x = 5 In Let y = 10 In x + y = 15;;")
 
 let test_if _ =
   assert_equal
-    (dde_eval "if false then 0 else 1;;")
+    (dde_eval_fb "if false then 0 else 1;;")
     (fb_eval "If False Then 0 Else 1;;");
   assert_equal
-    (dde_eval "let x = 1 in if x + 2 = 3 then x - 1 else x + 1;;")
+    (dde_eval_fb "let x = 1 in if x + 2 = 3 then x - 1 else x + 1;;")
     (fb_eval "Let x = 1 In If x + 2 = 3 Then x - 1 Else x + 1;;")
 
 let test_function _ =
-  assert_equal (dde_eval "fun x -> x;;") (fb_eval "Fun x -> x;;");
-  assert_equal (dde_eval "fun x -> 1;;") (fb_eval "Fun x -> 1;;");
+  assert_equal (dde_eval_fb "fun x -> x;;") (fb_eval "Fun x -> x;;");
+  assert_equal (dde_eval_fb "fun x -> 1;;") (fb_eval "Fun x -> 1;;");
   assert_equal
-    (dde_eval "fun x -> fun y -> fun z -> y;;")
+    (dde_eval_fb "fun x -> fun y -> fun z -> y;;")
     (fb_eval "Fun x -> Fun y -> Fun z -> y;;")
 
 let test_basic_application _ =
-  assert_equal (dde_eval "(fun x -> x) 1;;") (fb_eval "(Fun x -> x) 1;;");
-  assert_equal (dde_eval "(fun x -> 1) (-2);;") (fb_eval "(Fun x -> 1) (-2);;");
+  assert_equal (dde_eval_fb "(fun x -> x) 1;;") (fb_eval "(Fun x -> x) 1;;");
   assert_equal
-    (dde_eval "((fun x -> fun y -> y) 1) 2;;")
+    (dde_eval_fb "(fun x -> 1) (-2);;")
+    (fb_eval "(Fun x -> 1) (-2);;");
+  assert_equal
+    (dde_eval_fb "((fun x -> fun y -> y) 1) 2;;")
     (fb_eval "((Fun x -> Fun y -> y) 1) 2;;")
 
 let test_involved_application _ =
   assert_equal
-    (dde_eval "((fun x -> fun y -> x) 1) 2;;")
+    (dde_eval_fb "((fun x -> fun y -> x) 1) 2;;")
     (fb_eval "((Fun x -> Fun y -> x) 1) 2;;");
   assert_equal
-    (dde_eval "((fun x -> fun y -> y x) 1) (fun x -> x + 10);;")
+    (dde_eval_fb "((fun x -> fun y -> y x) 1) (fun x -> x + 10);;")
     (fb_eval "((Fun x -> Fun y -> y x) 1) (Fun x -> x + 10);;");
   assert_equal
-    (dde_eval "(fun x -> (fun y -> (fun z -> z + 1) y) (x + 2)) 6;;")
+    (dde_eval_fb "(fun x -> (fun y -> (fun z -> z + 1) y) (x + 2)) 6;;")
     (fb_eval "(Fun x -> (Fun y -> (Fun z -> z + 1) y) (x + 2)) 6;;");
-  (* call-by-name semantics *)
-  assert_unequal
-    (dde_eval "(fun x -> fun y -> x) (1 + 2);;")
+  assert_equal
+    (dde_eval_fb "(fun x -> fun y -> x) (1 + 2);;")
     (fb_eval "(Fun x -> Fun y -> x) (1 + 2);;")
 
 let dde_ycomb =
@@ -85,13 +86,13 @@ let fb_fib x =
 
 let test_ycomb _ =
   assert_equal
-    (dde_eval
+    (dde_eval_fb
        "let summate0 = fun self -> fun arg -> if arg = 0 then 0 else arg + \
         self self (arg - 1) in summate0 summate0 5;;")
     (fb_eval
        "Let summate0 = Fun self -> Fun arg -> If arg = 0 Then 0 Else arg + \
         self self (arg - 1) In summate0 summate0 5;;");
-  assert_equal (dde_eval @@ dde_fib 5) (fb_eval @@ fb_fib 5)
+  assert_equal (dde_eval_fb @@ dde_fib 5) (fb_eval @@ fb_fib 5)
 
 let dde_subst_tests =
   [

--- a/tests/utils.ml
+++ b/tests/utils.ml
@@ -1,55 +1,77 @@
 exception Unreachable
 
-let rec strip_label_subst (le : Ddeast.lexpr) : Fbast.expr =
-  let e, _ = le in
+let rec strip_label_fb (e : Ddeast.expr) : Fbast.expr =
   match e with
-  | Int i -> Int i
-  | Function (Ident x, e) -> Function (Ident x, strip_label_subst e)
-  | Bool b -> Bool b
-  | Appl (e1, e2) -> Appl (strip_label_subst e1, strip_label_subst e2)
-  | Var (Ident x) -> Var (Ident x)
-  | Plus (e1, e2) -> Plus (strip_label_subst e1, strip_label_subst e2)
-  | Minus (e1, e2) -> Minus (strip_label_subst e1, strip_label_subst e2)
-  | Equal (e1, e2) -> Equal (strip_label_subst e1, strip_label_subst e2)
-  | And (e1, e2) -> And (strip_label_subst e1, strip_label_subst e2)
-  | Or (e1, e2) -> Or (strip_label_subst e1, strip_label_subst e2)
-  | Not e -> Not (strip_label_subst e)
-  | If (e1, e2, e3) ->
-      If (strip_label_subst e1, strip_label_subst e2, strip_label_subst e3)
+  | Value value -> (
+      match value with
+      | Int i -> Int i
+      | Bool b -> Bool b
+      | Function (Ident x, e, _) -> Function (Ident x, strip_label_fb e))
+  | Appl (e1, e2, _) -> Appl (strip_label_fb e1, strip_label_fb e2)
+  | Var (Ident x, _) -> Var (Ident x)
+  | Plus (e1, e2, _) -> Plus (strip_label_fb e1, strip_label_fb e2)
+  | Minus (e1, e2, _) -> Minus (strip_label_fb e1, strip_label_fb e2)
+  | Equal (e1, e2, _) -> Equal (strip_label_fb e1, strip_label_fb e2)
+  | And (e1, e2, _) -> And (strip_label_fb e1, strip_label_fb e2)
+  | Or (e1, e2, _) -> Or (strip_label_fb e1, strip_label_fb e2)
+  | Not (e, _) -> Not (strip_label_fb e)
+  | If (e1, e2, e3, _) ->
+      If (strip_label_fb e1, strip_label_fb e2, strip_label_fb e3)
   | _ -> raise Unreachable
 
-let rec strip_label_env (le : Ddeast.lexpr) : Fbenvast.expr =
-  let e, _ = le in
+let rec strip_label_fbenv (e : Ddeast.expr) : Fbenvast.expr =
   match e with
-  | Int i -> Int i
-  | Function (Ident x, e) -> Function (Ident x, strip_label_env e)
-  | Bool b -> Bool b
-  | Appl (e1, e2) -> Appl (strip_label_env e1, strip_label_env e2)
-  | Var (Ident x) -> Var (Ident x)
-  | Plus (e1, e2) -> Plus (strip_label_env e1, strip_label_env e2)
-  | Minus (e1, e2) -> Minus (strip_label_env e1, strip_label_env e2)
-  | Equal (e1, e2) -> Equal (strip_label_env e1, strip_label_env e2)
-  | And (e1, e2) -> And (strip_label_env e1, strip_label_env e2)
-  | Or (e1, e2) -> Or (strip_label_env e1, strip_label_env e2)
-  | Not e -> Not (strip_label_env e)
-  | If (e1, e2, e3) ->
-      If (strip_label_env e1, strip_label_env e2, strip_label_env e3)
+  | Value value -> (
+      match value with
+      | Int i -> Int i
+      | Bool b -> Bool b
+      | Function (Ident x, e, _) -> Function (Ident x, strip_label_fbenv e))
+  | Appl (e1, e2, _) -> Appl (strip_label_fbenv e1, strip_label_fbenv e2)
+  | Var (Ident x, _) -> Var (Ident x)
+  | Plus (e1, e2, _) -> Plus (strip_label_fbenv e1, strip_label_fbenv e2)
+  | Minus (e1, e2, _) -> Minus (strip_label_fbenv e1, strip_label_fbenv e2)
+  | Equal (e1, e2, _) -> Equal (strip_label_fbenv e1, strip_label_fbenv e2)
+  | And (e1, e2, _) -> And (strip_label_fbenv e1, strip_label_fbenv e2)
+  | Or (e1, e2, _) -> Or (strip_label_fbenv e1, strip_label_fbenv e2)
+  | Not (e, _) -> Not (strip_label_fbenv e)
+  | If (e1, e2, e3, _) ->
+      If (strip_label_fbenv e1, strip_label_fbenv e2, strip_label_fbenv e3)
   | _ -> raise Unreachable
+
+let dde_to_fb (v : Ddeinterp.result_value) : Fbast.expr =
+  match v with
+  | IntResult i -> Int i
+  | BoolResult b -> Bool b
+  | FunctionResult { f; l; sigma } -> (
+      match f with
+      | Function (Ident x, le, _) -> Function (Ident x, strip_label_fb le)
+      | _ -> raise Unreachable)
+  | _ -> raise Unreachable
+
+let dde_to_fbenv (v : Ddeinterp.result_value) : Fbenvast.expr =
+  match v with
+  | IntResult i -> Int i
+  | BoolResult b -> Bool b
+  | FunctionResult { f; l; sigma } -> (
+      match f with
+      | Function (Ident x, le, _) -> Function (Ident x, strip_label_fbenv le)
+      | _ -> raise Unreachable)
+  | _ -> raise Unreachable
+
+let dde_eval_fb s =
+  Lexing.from_string s
+  |> Ddeparser.main Ddelexer.token
+  |> Ddeinterp.eval false |> dde_to_fb
+
+let dde_eval_fbenv s =
+  Lexing.from_string s
+  |> Ddeparser.main Ddelexer.token
+  |> Ddeinterp.eval false |> dde_to_fbenv
 
 let dde_parse s =
   s ^ ";;" |> Lexing.from_string
   |> Ddeparser.main Ddelexer.token
-  |> strip_label_subst
-
-let dde_eval s =
-  Lexing.from_string s
-  |> Ddeparser.main Ddelexer.token
-  |> Ddeinterp.eval false |> strip_label_subst
-
-let dde_eval_env s =
-  Lexing.from_string s
-  |> Ddeparser.main Ddelexer.token
-  |> Ddeinterp.eval false |> strip_label_env
+  |> strip_label_fb
 
 let fb_eval s =
   Lexing.from_string s |> Fbparser.main Fblexer.token |> Fbinterp.eval
@@ -57,6 +79,6 @@ let fb_eval s =
 let fbenv_eval s =
   Lexing.from_string s |> Fbenvparser.main Fbenvlexer.token |> Fbenvinterp.eval
 
-let dde_pp e = Format.printf "%a\n" Ddepp.pp_lexpr e
+let dde_pp e = Format.printf "%a\n" Ddepp.pp_expr e
 let fb_pp e = Format.printf "%a\n" Fbpp.pp_expr e
 let assert_unequal e1 e2 = OUnit2.assert_equal ~cmp:(fun a b -> a <> b) e1 e2


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

This PR re-establishes DDE against the semantics with runtime *result values*,
lazy binary/unary operations, etc. With this new semantics, DDE now avoids
labeling intermediate values (e.g., results of algebraic/boolean computations).
The semantics also makes it more explicit what language constructs are labeled
and what are not based on whether a label is necessary in the evaluation.

While DDE is lazy, a key change from the previous implementation is that
`eval` now eagerly performs variable substitution after DDE, yielding the
same results as forward interpreters (e.g., Fb). This is convenient for
testing against Fb/FbEnv. It is also harder to "simulate" DDE's laziness
during variable substitution due to the big-step relation now gives result
values instead of expressions, which must be either function, integer, or
boolean.

Test plan:

All tests pass.