### PR TITLE
[Infra] Add `--simplify` flag to optionally eagerly simplify the evaluation result

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ open Debugutils;; (* to simplify calling utility functions such as `peu` *)
 Debugutils.is_debug_mode := true;; (* or *)
 is_debug_mode := true;; (* to print debug information from the
 evaluation. *)
+
+Debugutils.should_simplify := true;; (* or *)
+should_simplify := true;; (* to perform variable substitution, function
+application, etc. on the evaluation result. *)
+
 ```
 
 ### Binary
@@ -43,6 +48,8 @@ Optionally pass in a file name to run the interpreter on the file:
 ```sh
 dune exec -- src/interpreter.exe <path-to-file> --debug
 ```
+
+Same applies to `--simplify`.
 
 ## Testing
 

--- a/src/ddeinterp.ml
+++ b/src/ddeinterp.ml
@@ -246,7 +246,7 @@ and eval_result_value (r : result_value) : result_value =
           | BoolResult b -> BoolResult (not b)
           | _ -> raise TypeMismatch [@coverage off]))
 
-let eval is_debug_mode e =
+let eval e ~is_debug_mode ~should_simplify =
   let e = transform_let e in
   fill_my_fun e None;
   let r = eval_helper e [] in
@@ -260,7 +260,9 @@ let eval is_debug_mode e =
      print_endline "****** MyFun Table ******\n")
     [@coverage off]);
 
-  let v = eval_result_value r in
-  Hashtbl.reset my_expr;
-  Hashtbl.reset my_fun;
-  v
+  if not should_simplify then r
+  else
+    let v = eval_result_value r in
+    Hashtbl.reset my_expr;
+    Hashtbl.reset my_fun;
+    v

--- a/src/ddepp.ml
+++ b/src/ddepp.ml
@@ -42,7 +42,7 @@ let rec pp_expr fmt (e : expr) =
       ff fmt "(@[<hv>let %s =@;<1 4>%a@;<1 0>In@;<1 4>%a@])^%d" i pp_expr e1
         pp_expr e2 l
 
-let pp_result_value fmt (v : result_value) =
+let rec pp_result_value fmt (v : result_value) =
   match v with
   | IntResult x -> ff fmt "%d" x
   | BoolResult b -> ff fmt "%b" b
@@ -51,7 +51,18 @@ let pp_result_value fmt (v : result_value) =
       | Function (Ident i, le, l) ->
           ff fmt "(@[<hv>function %s ->@;<1 4>%a@])^%d" i pp_expr le l
       | _ -> raise Unreachable)
-  | OpResult op -> raise Unreachable
+  | OpResult op -> (
+      match op with
+      | Plus (r1, r2) ->
+          ff fmt "(%a + %a)" pp_result_value r1 pp_result_value r2
+      | Minus (r1, r2) ->
+          ff fmt "(%a - %a)" pp_result_value r1 pp_result_value r2
+      | Equal (r1, r2) ->
+          ff fmt "(%a = %a)" pp_result_value r1 pp_result_value r2
+      | And (r1, r2) ->
+          ff fmt "(%a and %a)" pp_result_value r1 pp_result_value r2
+      | Or (r1, r2) -> ff fmt "(%a or %a)" pp_result_value r1 pp_result_value r2
+      | Not r1 -> ff fmt "(not %a)" pp_result_value r1)
 
 let rec pp_fbtype fmt = function
   | TArrow (t1, t2) ->

--- a/src/debugutils.ml
+++ b/src/debugutils.ml
@@ -1,6 +1,7 @@
 [@@@coverage off]
 
 let is_debug_mode = ref false
+let should_simplify = ref false
 let eval = Fbdk.Interpreter.eval
 
 let parse s =
@@ -8,15 +9,21 @@ let parse s =
   Fbdk.Parser.main Fbdk.Lexer.token lexbuf
 
 let unparse v = Format.asprintf "%a" Fbdk.Pp.pp_result_value v
-let parse_eval s = Fbdk.Interpreter.eval !is_debug_mode (parse s)
+
+let parse_eval s =
+  Fbdk.Interpreter.eval (parse s) ~is_debug_mode:!is_debug_mode
+    ~should_simplify:!should_simplify
 
 let parse_eval_unparse s =
-  unparse @@ Fbdk.Interpreter.eval !is_debug_mode (parse s)
+  unparse
+  @@ Fbdk.Interpreter.eval (parse s) ~is_debug_mode:!is_debug_mode
+       ~should_simplify:!should_simplify
 
 let peu = parse_eval_unparse
 
 let parse_eval_print s =
   Format.printf "==> %a\n" Fbdk.Pp.pp_result_value
-    (Fbdk.Interpreter.eval !is_debug_mode (parse s))
+    (Fbdk.Interpreter.eval (parse s) ~is_debug_mode:!is_debug_mode
+       ~should_simplify:!should_simplify)
 
 (* let pp s = s |> parse |> unparse |> print_string |> print_newline *)

--- a/src/fbdk.mli
+++ b/src/fbdk.mli
@@ -61,7 +61,8 @@ module Interpreter : sig
     | BoolResult of bool
     | OpResult of op_result_value
 
-  val eval : bool -> Ast.expr -> result_value
+  val eval :
+    Ast.expr -> is_debug_mode:bool -> should_simplify:bool -> result_value
 end
 
 module Pp : sig

--- a/src/interpreter.ml
+++ b/src/interpreter.ml
@@ -1,4 +1,5 @@
-let toplevel_loop typechecking_enabled show_types is_debug_mode =
+let toplevel_loop typechecking_enabled show_types is_debug_mode should_simplify
+    =
   (* Prints exceptions and associated stack traces *)
   let print_exception ex =
     Format.printf "Exception: %s\n" (Printexc.to_string ex);
@@ -41,7 +42,7 @@ let toplevel_loop typechecking_enabled show_types is_debug_mode =
   (* Interpret and print. Exceptions are caught and reported. But the toploop is not aborted *)
   let safe_interpret_and_print ast =
     try
-      let result = Fbdk.Interpreter.eval is_debug_mode ast in
+      let result = Fbdk.Interpreter.eval ast ~is_debug_mode ~should_simplify in
       Format.printf "==> %a\n" Fbdk.Pp.pp_result_value result
     with ex -> print_exception ex
   in
@@ -60,11 +61,11 @@ let toplevel_loop typechecking_enabled show_types is_debug_mode =
         Format.print_flush ()
   done
 
-let run_file filename is_debug_mode =
+let run_file filename is_debug_mode should_simplify =
   let fin = open_in filename in
   let lexbuf = Lexing.from_channel fin in
   let ast = Fbdk.Parser.main Fbdk.Lexer.token lexbuf in
-  let result = Fbdk.Interpreter.eval is_debug_mode ast in
+  let result = Fbdk.Interpreter.eval ast ~is_debug_mode ~should_simplify in
   Format.printf "%a\n" Fbdk.Pp.pp_result_value result;
   Format.print_flush ()
 
@@ -80,6 +81,7 @@ let main () =
   let no_type_display = ref false in
   let show_exception_stack_trace = ref false in
   let is_debug_mode = ref false in
+  let should_simplify = ref false in
   Arg.parse
     ([
        ("--version", Arg.Set version, "show version information");
@@ -92,6 +94,10 @@ let main () =
        ( "--debug",
          Arg.Set is_debug_mode,
          "output debug information from evaluation" );
+       ( "--simplify",
+         Arg.Set should_simplify,
+         "eagerly simplify (substitute free variables, perform function \
+          application, etc.)result" );
      ]
     @ Fbdk.Options.options)
     (function
@@ -106,6 +112,7 @@ let main () =
   if !version then print_version ()
   else if !toplevel then
     toplevel_loop (not !no_typechecking) (not !no_type_display) !is_debug_mode
-  else run_file !filename !is_debug_mode
+      !should_simplify
+  else run_file !filename !is_debug_mode !should_simplify
 
 let () = main ()

--- a/tests/utils.ml
+++ b/tests/utils.ml
@@ -61,12 +61,14 @@ let dde_to_fbenv (v : Ddeinterp.result_value) : Fbenvast.expr =
 let dde_eval_fb s =
   Lexing.from_string s
   |> Ddeparser.main Ddelexer.token
-  |> Ddeinterp.eval false |> dde_to_fb
+  |> Ddeinterp.eval ~is_debug_mode:false ~should_simplify:true
+  |> dde_to_fb
 
 let dde_eval_fbenv s =
   Lexing.from_string s
   |> Ddeparser.main Ddelexer.token
-  |> Ddeinterp.eval false |> dde_to_fbenv
+  |> Ddeinterp.eval ~is_debug_mode:false ~should_simplify:true
+  |> dde_to_fbenv
 
 let dde_parse s =
   s ^ ";;" |> Lexing.from_string


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

This PR adds `--simplify` and the debug variable `should_simplify` to allow
the user to opt into and out of performing variable substitution, function
application, etc. on DDE's output. While the test suite defaults to
simplification, this option makes it easier to see DDE's original behavior.

Test plan:

All test pass.