### PR TITLE
[Infra] Add debug utilities for program analysis

### DIFF
--- a/program_analysis/debugutils.ml
+++ b/program_analysis/debugutils.ml
@@ -1,0 +1,11 @@
+[@@@coverage off]
+
+let analyze = Lib.analyze
+let parse s = s ^ ";;" |> Lexing.from_string |> Ddeparser.main Ddelexer.token
+let unparse v = v |> Format.asprintf "%a" Utils.pp_result_value
+let parse_analyze s = s |> parse |> analyze
+let parse_analyze_unparse s = s |> parse |> analyze |> fst |> unparse
+let pau = parse_analyze_unparse
+
+let parse_eval_print s =
+  s |> parse |> analyze |> fst |> Format.printf "==> %a\n" Utils.pp_result_value

--- a/program_analysis/dune
+++ b/program_analysis/dune
@@ -1,6 +1,6 @@
 (library
  (name program_analysis)
- (modules lib utils)
+ (modules lib utils debugutils)
  (libraries dde))
 
 (executable


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #15
* #17
* __->__ #16
* #14
* #13

Per the title. Largely the same set of utility functions as DDE to facilitate
debugging program analysis in utop.