### PR TITLE
[PA] Stub cyclic expressions only at function application

### DIFF
--- a/program_analysis/lib.ml
+++ b/program_analysis/lib.ml
@@ -23,6 +23,7 @@ and result_value =
       sigma : sigma_t;
     }
   | FunResult of { f : expr; l : label_t; sigma : sigma_t }
+  (* TODO: don't store the entire expression *)
   | StubResult of { e : expr; sigma : sigma_t }
   | IntResult of int
   | BoolResult of bool
@@ -51,47 +52,42 @@ let rec find_choice f choices =
   | res :: rest -> if f res then res else find_choice f rest
   | [] -> failwith "choice not found" [@coverage off]
 
-(* pass in result-set pair to be returned if not visited *)
-let stub_base e sigma v res_pair =
-  match List.find_opt (fun (sigma', e') -> sigma = sigma' && e = e') v with
-  | Some _ -> (StubResult { e; sigma }, snd res_pair)
-  | None -> res_pair
-
-let rec stub_step e sigma set v =
-  match List.find_opt (fun (sigma', e') -> sigma = sigma' && e = e') v with
-  | Some _ -> (StubResult { e; sigma }, set)
-  | None -> analyze_aux e sigma set v
-
-(* TODO: can refactor to inline logic for Stub *)
-and analyze_aux e sigma set vis =
+let rec analyze_aux e sigma set vis =
   match e with
-  | Int i -> stub_base e sigma vis (IntResult i, set)
-  | Bool b -> stub_base e sigma vis (BoolResult b, set)
+  | Int i -> (IntResult i, set)
+  | Bool b -> (BoolResult b, set)
   | Function (_, _, l) ->
       (*? should ChoiceResult wrap all results? *)
-      stub_base e sigma vis
-        ( ChoiceResult { choices = [ FunResult { f = e; l; sigma } ]; l; sigma },
-          set )
+      ( ChoiceResult { choices = [ FunResult { f = e; l; sigma } ]; l; sigma },
+        set )
   | Appl (e', _, l) -> (
-      let vis' = (sigma, e) :: vis in
-      match stub_step e' sigma set vis' with
-      | ChoiceResult { choices; _ }, _ ->
-          let result_list, set_union =
-            fold_choices
-              (fun fun_res (result_accum, set_accum) ->
-                match fun_res with
-                | FunResult { f = Function (_, e_i, _); _ } ->
-                    let sigma' = l :: sigma in
-                    let res_i, set_i =
-                      (*? set element insertion notation is a bit off *)
-                      stub_step e_i (prune_sigma sigma') (sigma' :: set) vis'
-                    in
-                    (res_i :: result_accum, set_accum @ set_i)
-                | _ -> failwith "funresult (appl)" [@coverage off])
-              ([], []) choices
-          in
-          (ChoiceResult { choices = result_list; l; sigma }, set_union)
-      | _ -> failwith "choice (appl)" [@coverage off])
+      (* Stub *)
+      let sigma_app_l = prune_sigma (l :: sigma) in
+      match
+        List.find_opt (fun (e', sigma') -> e = e' && sigma_app_l = sigma') vis
+      with
+      | Some _ -> (StubResult { e; sigma = sigma_app_l }, set)
+      | None -> (
+          (* Application *)
+          match analyze_aux e' sigma set vis with
+          | ChoiceResult { choices; _ }, set_1 ->
+              let result_list, set_union =
+                fold_choices
+                  (fun fun_res (result_accum, set_accum) ->
+                    match fun_res with
+                    | FunResult { f = Function (_, e_i, _); _ } ->
+                        let res_i, set_i =
+                          analyze_aux e_i sigma_app_l
+                            ((l :: sigma) :: set_accum)
+                            ((e, sigma_app_l) :: vis)
+                        in
+                        (res_i :: result_accum, set_i)
+                    | _ -> failwith "funresult (appl)" [@coverage off])
+                  ([], []) choices
+              in
+              ( ChoiceResult { choices = result_list; l; sigma = sigma_app_l },
+                set_union )
+          | _ -> failwith "choice (appl)" [@coverage off]))
   | Var (Ident x, l) -> (
       let sigma_hd = List.hd sigma in
       let sigma_tl = List.tl sigma in
@@ -110,7 +106,8 @@ and analyze_aux e sigma set vis =
                         && contains_sigma (List.tl sigma_i) sigma_tl
                       then
                         let res_i, set_i =
-                          stub_step e2 (List.tl sigma_i) set ((sigma, e) :: vis)
+                          analyze_aux e2 (List.tl sigma_i) set
+                            ((e, sigma) :: vis)
                         in
                         (* TODO: use hashset for S *)
                         (res_i :: result_accum, set_i @ set_accum)
@@ -124,8 +121,8 @@ and analyze_aux e sigma set vis =
             (* Var Non-Local *)
             match get_expr sigma_hd with
             | Appl (e1, _, l2) -> (
-                let vis' = (sigma, e) :: vis in
-                match stub_step e1 sigma set vis' with
+                let vis' = (e, sigma) :: vis in
+                match analyze_aux e1 sigma set vis' with
                 | ChoiceResult { choices; _ }, set1 -> (
                     (* TODO: disjunction; function with different sigmas *)
                     let fun_res =
@@ -136,7 +133,7 @@ and analyze_aux e sigma set vis =
                     in
                     match fun_res with
                     | FunResult { f; l = l1; sigma = sigma1 } ->
-                        stub_step (Var (Ident x, l1)) sigma1 set1 vis'
+                        analyze_aux (Var (Ident x, l1)) sigma1 set1 vis'
                     | _ -> failwith "fun" [@coverage off])
                 | _ -> failwith "choice" [@coverage off])
             | _ -> failwith "appl" [@coverage off])
@@ -144,40 +141,40 @@ and analyze_aux e sigma set vis =
   | Plus (e1, e2, _) ->
       (* hereafter we use short forms `r1` (`res1`), `s2` (`set2`), etc.
          as code is clearer here and thus they are less ambiguous. *)
-      let vis' = (sigma, e) :: vis in
-      let r1, s1 = stub_step e1 sigma set vis' in
-      let r2, s2 = stub_step e2 sigma s1 vis' in
+      let vis' = (e, sigma) :: vis in
+      let r1, s1 = analyze_aux e1 sigma set vis' in
+      let r2, s2 = analyze_aux e2 sigma s1 vis' in
       (OpResult (PlusOp (r1, r2)), s2)
   | Minus (e1, e2, _) ->
-      let vis' = (sigma, e) :: vis in
-      let r1, s1 = stub_step e1 sigma set vis' in
-      let r2, s2 = stub_step e2 sigma s1 vis' in
+      let vis' = (e, sigma) :: vis in
+      let r1, s1 = analyze_aux e1 sigma set vis' in
+      let r2, s2 = analyze_aux e2 sigma s1 vis' in
       (OpResult (MinusOp (r1, r2)), s2)
   | Equal (e1, e2, _) ->
-      let vis' = (sigma, e) :: vis in
-      let r1, s1 = stub_step e1 sigma set vis' in
-      let r2, s2 = stub_step e2 sigma s1 vis' in
+      let vis' = (e, sigma) :: vis in
+      let r1, s1 = analyze_aux e1 sigma set vis' in
+      let r2, s2 = analyze_aux e2 sigma s1 vis' in
       (OpResult (EqualOp (r1, r2)), s2)
   | And (e1, e2, _) ->
-      let vis' = (sigma, e) :: vis in
-      let r1, s1 = stub_step e1 sigma set vis' in
-      let r2, s2 = stub_step e2 sigma s1 vis' in
+      let vis' = (e, sigma) :: vis in
+      let r1, s1 = analyze_aux e1 sigma set vis' in
+      let r2, s2 = analyze_aux e2 sigma s1 vis' in
       (OpResult (AndOp (r1, r2)), s2)
   | Or (e1, e2, _) ->
-      let vis' = (sigma, e) :: vis in
-      let r1, s1 = stub_step e1 sigma set vis' in
-      let r2, s2 = stub_step e2 sigma s1 vis' in
+      let vis' = (e, sigma) :: vis in
+      let r1, s1 = analyze_aux e1 sigma set vis' in
+      let r2, s2 = analyze_aux e2 sigma s1 vis' in
       (OpResult (OrOp (r1, r2)), s2)
   | Not (e', _) ->
-      let r, s = stub_step e' sigma set ((sigma, e) :: vis) in
+      let r, s = analyze_aux e' sigma set ((e, sigma) :: vis) in
       (OpResult (NotOp r), s)
   | If (e', e1, e2, l) ->
-      let vis' = (sigma, e) :: vis in
-      let _r, s0 = stub_step e' sigma set vis' in
+      let vis' = (e, sigma) :: vis in
+      let _r, s0 = analyze_aux e' sigma set vis' in
       (* TODO: eval r *)
       (* on stub, denote as `anynum` *)
-      let r_true, s_true = stub_step e1 sigma set vis' in
-      let r_false, s_false = stub_step e2 sigma set vis' in
+      let r_true, s_true = analyze_aux e1 sigma set vis' in
+      let r_false, s_false = analyze_aux e2 sigma set vis' in
       ( ChoiceResult { choices = [ r_true; r_false ]; l; sigma },
         s0 @ s_true @ s_false )
   | Let _ -> raise Unreachable [@coverage off]

--- a/program_analysis/lib.ml
+++ b/program_analysis/lib.ml
@@ -83,7 +83,7 @@ let rec analyze_aux e sigma set vis =
                         in
                         (res_i :: result_accum, set_i)
                     | _ -> failwith "funresult (appl)" [@coverage off])
-                  ([], []) choices
+                  ([], set_1) choices
               in
               ( ChoiceResult { choices = result_list; l; sigma = sigma_app_l },
                 set_union )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #22
* __->__ #21

Since function application is the only rule where the call site stack
`sigma` is extended (and added to the V(isited) set), we "inline" the
Stub rule to only be applied here, at the origin of cycles in the
program analysis.