### PR TITLE
[Fix][PA] Resolve issue with Var Non-Local rule

### DIFF
--- a/program_analysis/lib.ml
+++ b/program_analysis/lib.ml
@@ -102,7 +102,7 @@ let rec analyze_aux e sigma =
             (* Var Non-Local *)
             match get_expr sigma_hd with
             | Appl (e1, _, l2) -> (
-                match analyze_aux e1 sigma with
+                match analyze_aux e1 sigma_tl with
                 | ChoiceResult { choices; _ } ->
                     let result_list =
                       fold_choices
@@ -113,7 +113,8 @@ let rec analyze_aux e sigma =
                                 f = Function (Ident x1, _, _);
                                 l = l1;
                                 sigma = sigma_i;
-                              } ->
+                              }
+                            when x <> x1 ->
                               analyze_aux (Var (Ident x, l1)) sigma_i :: accum
                           | _ -> accum)
                         [] choices


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #24
* __->__ #25

Fix a bug where non-local variables are looked up inaccurately by
recursively calling `analyze_aux` with the stack *after* popping off
the top function application.

Test plan:

This test case:

```ocaml
pau "(fun x -> (fun y -> x + y) 2) 1";;
```

should give "| | (| | 1 + | 2)"; not "| | (| | 2 + | 2)".