### PR TITLE
[Fix][PA] Avoid false positives when stubbing function applications

### DIFF
--- a/program_analysis/lib.ml
+++ b/program_analysis/lib.ml
@@ -46,7 +46,7 @@ let rec fold_choices f accum choices =
 let set : sigma_t Hashset.t = Hashset.create 100
 let vis : (expr * sigma_t) Hashset.t = Hashset.create 50
 
-let rec analyze_aux e sigma =
+let rec analyze_aux ?(stub = true) e sigma =
   match e with
   | Int i -> IntResult i
   | Bool b -> BoolResult b
@@ -54,9 +54,9 @@ let rec analyze_aux e sigma =
       (*? should ChoiceResult wrap all results? *)
       ChoiceResult { choices = [ FunResult { f = e; l; sigma } ]; l; sigma }
   | Appl (e', _, l) -> (
-      (* Stub *)
       let sigma_app_l = prune_sigma (l :: sigma) in
-      if Hashset.mem vis (e, sigma_app_l) then
+      (* Stub *)
+      if stub && Hashset.mem vis (e, sigma_app_l) then
         StubResult { e; sigma = sigma_app_l }
       else
         (* Application *)
@@ -102,7 +102,7 @@ let rec analyze_aux e sigma =
             (* Var Non-Local *)
             match get_expr sigma_hd with
             | Appl (e1, _, l2) -> (
-                match analyze_aux e1 sigma_tl with
+                match analyze_aux e1 sigma_tl ~stub:false with
                 | ChoiceResult { choices; _ } ->
                     let result_list =
                       fold_choices

--- a/program_analysis/tests/tests_self.ml
+++ b/program_analysis/tests/tests_self.ml
@@ -1,6 +1,15 @@
 open OUnit2
 open Test_utils
 
-let test_basics _ = assert_equal "| | 1" (pau "(fun x -> x) 1;;")
-let pa_self_tests = [ "Basics" >:: test_basics ]
+let test_basics _ =
+  assert_equal "| | 1" (pau "(fun x -> x) 1;;");
+  assert_equal "| (1 + | 2)" (pau "(fun y -> 1 + y) 2;;")
+
+let test_nonlocal _ =
+  assert_equal "| (| | 1 + | 2)" (pau "((fun x -> fun y -> x + y) 1) 2;;");
+  assert_equal "| | (| | 1 + | 2)" (pau "(fun x -> (fun y -> x + y) 2) 1;;")
+
+let pa_self_tests =
+  [ "Basics" >:: test_basics; "Non-local variable lookup" >:: test_nonlocal ]
+
 let pa_self = "Program analysis against self" >::: pa_self_tests


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #26
* #24

We only want to stub a function application when it really is the source
of a cycle in the program. For a program like
`((fun x -> fun y -> x + y) 1) 2`, we do not want to trigger the Stub
rule just because the inner application has already been visited when
getting to the non-local variable `x`, since this program is acyclic.

Thus, the resolution is to add an optional paramter to `analyze_aux`
that, when set to `false`, skips the Stub rule for function
applications. It defaults to `true`.

Test plan:

All tests pass, including the aforementioned one.