### PR TITLE
[Infra] Generate coverage files in _build

### DIFF
--- a/dune-workspace
+++ b/dune-workspace
@@ -6,3 +6,5 @@
  (_
   (flags
    (:standard -w -27-33-39))))
+
+(instrument_with bisect_ppx)

--- a/interpreter/src/dune
+++ b/interpreter/src/dune
@@ -3,6 +3,8 @@
  (public_name dde.interpreter)
  (preprocess
   (pps ppx_deriving.show bisect_ppx ppx_jane))
+ (instrumentation
+  (backend bisect_ppx --bisect-file _build/bisect))
  (modules fbdk debugutils version ast type interp lexer options parser pp))
 
 (ocamllex

--- a/program_analysis/src/dune
+++ b/program_analysis/src/dune
@@ -1,6 +1,10 @@
 (library
  (name program_analysis)
  (public_name dde.program_analysis)
+ (preprocess
+  (pps bisect_ppx))
+ (instrumentation
+  (backend bisect_ppx --bisect-file _build/bisect))
  (modules lib utils debugutils)
  (libraries dde.interpreter hashset))
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #33
* #31
* #30

This is a quality of life improvement to declutter the root directory by
generating bisect_ppx coverage files in _build instead.