### PR TITLE
[Formal] Simplify notations and fix notation scoping

### DIFF
--- a/formal/Core.v
+++ b/formal/Core.v
@@ -95,7 +95,9 @@ Fixpoint build_mylexpr (le : lexpr) (ml : mylexpr) : mylexpr :=
 
 (* Compute build_mylexpr <{ (fun X -> X@1 ) @@ 2 }> empty. *)
 
-(* custom syntax for evaluation; I try to mirror the written syntax as much as possible *)
+(* custom syntax for evaluation, mirroring the written syntax
+   as much as possible. Uses '/' instead of ',' so notation doesn't
+   clash with that of Ltac's match goal. *)
 Reserved Notation
          "mf / ml / s |- e => r"
          (at level 40, e custom lang at level 99, r custom lang at level 99,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #42
* #49
* __->__ #48
* #47

Takes a more disciplined approach to defining notations for the core DDE
language, reflected through better precedence levels and correspondence
between notations and grammar. The result is more concise and more
versatile notations.

This commit also switches to using function types for constructors of
inductive type definitions over using constructor arguments because the
former is arguably more concise.

Test plan:

`make` to see that everything typechecks.