### PR TITLE
[Formal] Simplify Core.v logic and proofs

### DIFF
--- a/formal/Concrete/Core.v
+++ b/formal/Concrete/Core.v
@@ -111,23 +111,21 @@ Inductive eval : lexpr -> sigma -> res -> myfun -> mylexpr -> Prop :=
     mf / ml / s |- e1 => [ fun x -> e, l1, s1 ] ->
     mf / ml / l :: s |- e => r ->
     mf / ml / s |- (e1 <- e2) @ l => r
-  | E_VarLocal : forall (x : string) l s r mf ml e1 e2 l' e mf_l,
-    List.length s <> 0 ->
-    (* hd will never give default *)
-    ml (hd 0 s) = Some <{ (e1 <- e2) @ l' }> ->
+  | E_VarLocal : forall x l s r mf ml e1 e2 l' e mf_l,
+    ml l' = Some <{ (e1 <- e2) @ l' }> ->
     mf l = Some mf_l ->
     ml mf_l = Some <{ ($fun x -> e) @ mf_l }> ->
-    mf / ml / tl s |- e2 => r ->
-    mf / ml / s |- x@l => r
-  | E_VarNonLocal : forall (x : string) l s r mf ml e1 e2 l2 e mf_l x1 s1,
-    List.length s <> 0 ->
-    ml (hd 0 s) = Some <{ (e1 <- e2) @ l2 }> ->
-    mf l = Some mf_l ->
-    ml mf_l = Some <{ ($fun x1 -> e) @ mf_l }> ->
+    mf / ml / s |- e2 => r ->
+    mf / ml / (l' :: s) |- x@l => r
+  | E_VarNonLocal : forall x l s r mf ml e1 e2 l2 e l1 x1 s1,
+    mf l = Some l1 ->
+    ml l1 = Some <{ ($fun x1 -> e) @ l1 }> ->
     x <> x1 ->
-    mf / ml / tl s |- e1 => [ fun x1 -> e, mf_l, s1 ] ->
-    mf / ml / s1 |- x@mf_l => r ->
-    mf / ml / s |- x@l => r
+    ml l2 = Some <{ (e1 <- e2) @ l2 }> ->
+    mf / ml / s |- e1 => [ fun x1 -> e, l1, s1 ] ->
+    mf / ml / s1 |- x@l1 => r ->
+    (* TODO: inline premises *)
+    mf / ml / (l2 :: s) |- x@l => r
 
   where "mf / ml / s |- e => r" := (eval e s r mf ml).
 
@@ -164,7 +162,6 @@ Proof.
   eapply E_Appl.
   - apply E_Val.
   - eapply E_VarLocal.
-    + auto.
     + unfold eg_loc_ml, eg_loc. autounfold. reflexivity.
     + unfold eg_loc_mf, eg_loc. autounfold. reflexivity.
     + unfold eg_loc_ml, eg_loc. autounfold. reflexivity.
@@ -189,17 +186,15 @@ Proof.
     + apply E_Val.
     + apply E_Val.
   - eapply E_VarNonLocal.
-    + auto.
     + reflexivity.
     + reflexivity.
-    + unfold eg_noloc_ml, eg_noloc. autounfold. reflexivity.
-    + intro contra. discriminate contra.
+    + discriminate.
+    + reflexivity.
     (* N.B. that we re-do the application here, as expected from the rules *)
     + eapply E_Appl.
       * apply E_Val.
       * apply E_Val.
     + eapply E_VarLocal.
-      * auto.
       * reflexivity.
       * reflexivity.
       * reflexivity.
@@ -226,20 +221,20 @@ Proof.
   (* E_VarLocal *)
   - map_lookup eg_noloc_mf eg_noloc.
     map_lookup eg_noloc_ml eg_noloc.
-    discriminate H4.
+    discriminate H9.
   (* E_VarNonLocal *)
   - map_lookup eg_noloc_ml eg_noloc.
     map_lookup eg_noloc_mf eg_noloc.
     map_lookup eg_noloc_ml eg_noloc.
-    inversion H6. subst. clear H6.
-    inversion H9. subst. clear H9.
-    inversion H10. subst. clear H10.
+    inversion H11. subst. clear H11.
+    inversion H7. subst. clear H7.
+    inversion H8. subst. clear H8.
     inversion H12; subst; clear H12.
     (* E_VarLocal *)
     + map_lookup eg_noloc_ml eg_noloc.
       map_lookup eg_noloc_mf eg_noloc.
       map_lookup eg_noloc_ml eg_noloc.
-      inversion H11.
+      inversion H10.
     (* E_VarNonLocal *)
     + map_lookup eg_noloc_ml eg_noloc.
       map_lookup eg_noloc_mf eg_noloc.
@@ -267,22 +262,21 @@ Proof.
     apply IHeval1 in H9. injection H9 as H9. subst.
     apply IHeval2 in H10. assumption.
   (* E_VarLocal *)
-  - inversion H4; subst; clear H4.
+  - inversion H3; subst; clear H3.
     (* E_VarLocal *)
-    + repeat injection_subst.
-      clear H. clear H7.
-      apply IHeval in H15. assumption.
+    + repeat injection_subst. clear H2.
+      apply IHeval in H14. assumption.
     (* E_VarNonLocal *)
     + congruence.
   (* E_VarNonLocal *)
-  - inversion H6; subst; clear H6.
+  - inversion H5; subst; clear H5.
     (* E_VarLocal *)
     + congruence.
     (* E_VarNonLocal *)
     + repeat injection_subst.
-      clear H. clear H9.
-      apply IHeval1 in H14. injection H14 as H14. subst.
-      apply IHeval2 in H19. assumption.
+      clear H3. clear H4.
+      apply IHeval1 in H17. injection H17 as H17. subst.
+      apply IHeval2 in H18. assumption.
 Qed.
 
 Close Scope lang_scope.

--- a/formal/Concrete/Core.v
+++ b/formal/Concrete/Core.v
@@ -1,7 +1,7 @@
 Set Warnings "-notation-overridden,-parsing,-deprecated-hint-without-locality".
 From Coq Require Import Strings.String Lists.List Arith.Arith.
-From DDE Require Import Maps.
 Import ListNotations.
+From DDE Require Import Maps.
 
 (* slightly adjusted grammar to more easily define notations *)
 Inductive expr : Type :=
@@ -124,7 +124,6 @@ Inductive eval : lexpr -> sigma -> res -> myfun -> mylexpr -> Prop :=
     ml l2 = Some <{ (e1 <- e2) @ l2 }> ->
     mf / ml / s |- e1 => [ fun x1 -> e, l1, s1 ] ->
     mf / ml / s1 |- x@l1 => r ->
-    (* TODO: inline premises *)
     mf / ml / (l2 :: s) |- x@l => r
 
   where "mf / ml / s |- e => r" := (eval e s r mf ml).


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #52
* #53
* __->__ #54

Per title. Some premises of the `eval` logic can and have been inlined,
resulting in slightly shorter proofs.

Test plan:

`dune build` to see that everything compiles.