### PR TITLE
[Formal] Auto-assign expression labels

### DIFF
--- a/formal/Abstract/Pure.v
+++ b/formal/Abstract/Pure.v
@@ -22,34 +22,34 @@ Inductive analyze : sigma -> s_set -> lexpr -> res -> s_set -> Prop :=
   | E_Val : forall s S v l,
     s / S |-a ($v)@l => [ v, l, s ] / S
   | E_Appl : forall s S e1 e2 l rv Sv x e l1 s1 S1,
-    s / S |-a e1 => [ fun x -> e, l1, s1 ] / S1 ->
+    s / S |-a e1 => [ fun x *-> e, l1, s1 ] / S1 ->
     prune_sigma (l :: s) 2 [] / ((l :: s) :: S1) |-a e => rv / Sv ->
-    s / S |-a (e1 <- e2) @ l => rv / Sv
+    s / S |-a (e1 <-* e2) @ l => rv / Sv
   (* TODO: should s' be universally/existentially quantified? *)
   | E_VarLocal : forall e1 e2 l' s S x l rv Sv mf mf_l e ml s',
     mf l = mf_l ->
-    ml mf_l = Some <{ ($fun x -> e) @ mf_l }> ->
-    ml l' = Some <{ (e1 <- e2) @ l' }> ->
+    ml mf_l = Some <{ ($fun x *-> e) @ mf_l }> ->
+    ml l' = Some <{ (e1 <-* e2) @ l' }> ->
     (exists s0, In s0 S /\ s0 = l' :: s ++ s') ->
     (s ++ s') / S |-a e2 => rv / Sv ->
     (l' :: s) / S |-a x@l => rv / Sv
   | E_VarNonLocal : forall e1 e2 l2 s S x l rv Sv mf x1 e ml l1 s1 S1,
     mf l = l1 ->
-    ml l1 = Some <{ ($fun x1 -> e) @ l1 }> ->
+    ml l1 = Some <{ ($fun x1 *-> e) @ l1 }> ->
     x <> x1 ->
-    ml l2 = Some <{ (e1 <- e2) @ l2 }> ->
-    s / S |-a e1 => [ fun x1 -> e, l1, s1] / S1 ->
+    ml l2 = Some <{ (e1 <-* e2) @ l2 }> ->
+    s / S |-a e1 => [ fun x1 *-> e, l1, s1] / S1 ->
     s1 / S1 |-a x@l1 => rv / Sv ->
     (l2 :: s) / S |-a x@l => rv / Sv
 
   where "s / S '|-a' e => rv / Sv" := (analyze s S e rv Sv).
 
+Definition Self : string := "self".
+Definition self_fun := <{ $fun Self -> $fun N -> Self <- Self }>.
+
 Definition eg_recursion :=
-  <{ (((($fun X ->
-      ($fun N ->
-          (((X@0 <- X@1) @ 2) <- N@3) @ 4) @ 5) @ 6
-      <- ($fun Y -> Y@7) @ 8) @ 9)
-      <- ($fun Z -> Z@10) @ 11) @ 12 }>.
+  to_lexpr <{ self_fun <- self_fun <- $fun X -> X }>.
+(* Compute eg_recursion. *)
 
 Theorem analyze_nondeterministic :
   ~ forall s S e Sv rv1 rv2,

--- a/formal/Common/Lang.v
+++ b/formal/Common/Lang.v
@@ -1,14 +1,17 @@
-From DDE Require Export Maps.
 From Coq Require Export Lists.List.
 Export ListNotations.
+From DDE Require Export Maps.
 
 (* slightly adjusted grammar to more easily define notations *)
 Inductive expr : Type :=
-  | Appl: lexpr -> lexpr -> expr
+  | Appl: expr -> expr -> expr
+  | LAppl: lexpr -> lexpr -> expr
   | Val: val -> expr
   | Ident: string -> expr
-with lexpr : Type := Lexpr : expr -> nat -> lexpr
-with val : Type := Fun : string -> lexpr -> val.
+with val : Type :=
+  | Fun : string -> expr -> val
+  | LFun : string -> lexpr -> val
+with lexpr : Type := Lexpr : expr -> nat -> lexpr.
 
 Definition sigma : Type := list nat.
 
@@ -27,9 +30,15 @@ Notation "x" := x (in custom lang at level 0, x constr at level 0) : lang_scope.
 Notation "'fun' x -> e" :=
   (Fun x e)
     (in custom lang at level 20, e at next level, right associativity) : lang_scope.
+Notation "'fun' x '*->' le" :=
+  (LFun x le)
+    (in custom lang at level 20, le at next level, right associativity) : lang_scope.
 Notation "e1 <- e2" :=
   (Appl e1 e2)
-    (* associativity doesn't matter here as e1 and e2 are lexprs *)
+    (in custom lang at level 30, left associativity).
+Notation "le1 '<-*' le2" :=
+  (LAppl le1 le2)
+    (* associativity doesn't matter here as le1 and le2 are lexprs *)
     (in custom lang at level 30, left associativity).
 Notation "$ v" :=
   (Val v)
@@ -49,13 +58,35 @@ Definition Z : string := "z".
 Definition M : string := "m".
 Definition N : string := "n".
 
-(* TODO: auto-generate labels *)
-Example sample_ident := <{ X@0 }>.
-Example sample_fun := <{ fun X -> X@0 }>.
-Example sample_fun_lexpr := <{ ($fun X -> X@0) @ 1 }>.
-Example sample_fun_lexpr' := <{ ($fun X -> ($fun Y -> X@0) @ 1) @ 2 }>.
-Example sample_appl := <{ (X@0 <- X@1) @ 2}>.
-Example sample_res := <{ [ fun X -> X@0, 1, 0 :: [] ] }>.
+(* assign a label to each expr, turning it into an lexpr. *)
+Fixpoint assign_labels (e : expr) (l : nat) : lexpr * nat :=
+  match e with
+  | <{ e1 <- e2 }> =>
+    let (le1, l1) := assign_labels e1 l in
+    let (le2, l2) := assign_labels e2 l1 in
+    (<{ (le1 <-* le2) @ l2 }>, S l2)
+  | <{ le1 <-* le2 }> => (le1, l) (* unreachable *)
+  | <{ $v }> =>
+    match v with
+    | <{ fun x -> e' }> =>
+      let (le', l') := assign_labels e' l in
+      (<{ ($fun x *-> le') @ l' }>, S l')
+    | <{ fun _ *-> le' }> => (le', l) (* unreachable *)
+    end
+  | Ident _ => (<{ e @ l }>, S l)
+  end.
+
+Definition to_lexpr (e : expr) := fst (assign_labels e 0).
+
+Example sample_fun := to_lexpr <{ $fun X -> X }>.
+Example sample_fun' := to_lexpr <{ $fun X -> $fun Y -> X }>.
+(* Compute sample_fun'. *)
+Example sample_fun'' := to_lexpr <{ $fun X -> (X <- X) }>.
+(* Compute sample_fun''. *)
+Example sample_appl := to_lexpr <{ ($fun X -> X) <- ($fun X -> X) }>.
+Example sample_appl' := to_lexpr <{ X <- X }>.
+(* Compute sample_appl'. *)
+Example sample_res := <{ [ fun X *-> X@0, 1, 2 :: [] ] }>.
 
 Definition myfun : Type := partial_map nat nat.
 Definition mylexpr : Type := partial_map nat lexpr.
@@ -65,31 +96,39 @@ Fixpoint build_myfun (le : lexpr) (mf_l : option nat) (mf : myfun) : myfun :=
   match le with
   | <{ e @ l }> =>
     match e with
-    | Val v =>
+    | <{ $v }> =>
       match v with
-      | <{ fun _ -> e' }> => build_myfun e' (Some l) (l !-> mf_l; mf)
+      | <{ fun _ *-> le' }> => build_myfun le' (Some l) (l !-> mf_l; mf)
+      | <{ fun _ -> _ }> => mf (* unreachable *)
       end
     | Ident _ => (l !-> mf_l; mf)
-    | <{ e1 <- e2 }> => build_myfun e2 mf_l (build_myfun e1 mf_l mf)
+    | <{ le1 <-* le2 }> => build_myfun le2 mf_l (build_myfun le1 mf_l mf)
+    | <{ _ <- _ }> => mf (* unreachable *)
     end
   end.
 
-(* Compute build_myfun <{ (fun X -> X@1 ) @@ 2 }> None empty. *)
+(* Compute build_myfun (to_lexpr <{ $fun X -> X }>) None empty. *)
 
 (* build mapping from label to lexpr given a root lexpr *)
 Fixpoint build_mylexpr (le : lexpr) (ml : mylexpr) : mylexpr :=
   match le with
   | <{ e @ l }> =>
     match e with
-    | Val v =>
+    | <{ $v }> =>
       match v with
-      | <{ fun _ -> e' }> => (l |-> le; build_mylexpr e' ml)
+      | <{ fun _ *-> le' }> => (l |-> le; build_mylexpr le' ml)
+      | <{ fun _ -> _ }> => ml (* unreachable *)
       end
     | Ident _ => (l |-> le; ml)
-    | <{ e1 <- e2 }> => (l |-> le; build_mylexpr e2 (build_mylexpr e1 ml))
+    | <{ le1 <-* le2 }> => (l |-> le; build_mylexpr le2 (build_mylexpr le1 ml))
+    | <{ _ <- _ }> => ml (* unreachable *)
     end
   end.
 
-(* Compute build_mylexpr <{ (fun X -> X@1 ) @@ 2 }> empty. *)
+(* Compute build_mylexpr (to_lexpr <{ $fun X -> X }>) empty. *)
+
+(* TODO: prove properties of above functions,
+  like number of labels must be number of expr's,
+  and size of mylexpr must be number of lexpr's *)
 
 #[export] Hint Unfold build_myfun build_mylexpr update t_update : core.

--- a/formal/Common/Maps.v
+++ b/formal/Common/Maps.v
@@ -8,11 +8,11 @@ Class Eqb (A : Type) := {
   eqb: A -> A -> bool
 }.
 
-#[global] Instance nat_Eqb : Eqb nat := {
+#[export] Instance nat_Eqb : Eqb nat := {
   eqb x y := Nat.eqb x y
 }.
 
-#[global] Instance string_Eqb : Eqb string := {
+#[export] Instance string_Eqb : Eqb string := {
   eqb x y := String.eqb x y
 }.
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #61
* #60
* __->__ #58

A DDE expr can now be labeled and turned into an lexpr automatically.
It's now much more convenient to write complex programs.

To make this work, unlabeled versions of Appl and Fun are added
alongside the labeled versions in the type definition. Alternate
notations are also defined for them, like `<-*` for `LAppl` and `->*`
for `LFun`.

The drawback is that helper functions to assign labels and build maps
now have to match cases that are in practice unreachable yet has to
return values due to Coq being purely functional.

However, we do prove `assign_labels` sound in terms of realistic usage.
Proofs of `build_myfun` and `build_mylexpr` will come in the future.

Test plan:

`dune build` to see that everything compiles.