### PR TITLE
[Formal][Refactor] Simplify notations and proofs

### DIFF
--- a/formal/Abstract/AllPaths.v
+++ b/formal/Abstract/AllPaths.v
@@ -12,37 +12,36 @@ Definition disj : Type := list res.
 Reserved Notation
          "mf ; ml ; s ; S ; V '|-aa' e => rc / Sv"
          (at level 40, e custom lang at level 99, rc at next level,
-          ml at next level, s at next level, S at next level, V at next level,
-          Sv constr).
+          ml at next level, s at next level, S at next level, V at next level).
           
 (* union operation seen in Application *)
 Reserved Notation
          "mf ; ml ; s ; S ; V '|_A_|' r1 => r2 + S2"
-         (at level 40, r1 constr at level 99,
+         (at level 40, r1 at level 99,
           ml at next level, s at next level, S at next level, V at next level,
-          r2 at next level, S2 constr).
+          r2 at next level).
 
 (* stack stitching union operation *)
 Reserved Notation
          "mf ; ml ; s ; V ; l' ; e2 '|_V_|' S => r2 + S2"
-         (at level 40, S constr at level 99, e2 custom lang at level 99,
+         (at level 40, S at level 99, e2 custom lang at level 99,
           ml at next level, s at next level, V at next level, l' at next level,
-          r2 at next level, S2 constr).
+          r2 at next level).
 
 (* TODO: use better syntax to distinguish from above *)
 (* union operation seen in Var Non-Local *)
 Reserved Notation
          "mf ; ml ; S ; V ; x : l1 '|_N_|' r1 => r2 + S2"
-         (at level 40, r1 constr at level 99,
+         (at level 40, r1 at level 99,
           ml at next level, S at next level, V at next level,
           x at next level, l1 at next level,
-          r2 at next level, S2 constr).
+          r2 at next level).
 
 Inductive analyze
   : myfun -> mylexpr -> sigma -> s_set -> v_set -> lexpr -> disj -> s_set -> Prop
 :=
   | A_Val : forall mf ml s S V v l,
-    mf; ml; s; S; V |-aa ($v)@l => [<{ [ v, l, s ] }>] / S
+    mf; ml; s; S; V |-aa ($v)@l => [<v, l, s>] / S
   | A_Appl : forall mf ml s S V e e' l r2 S2 r1 S1 ls ls_pruned,
     mf; ml; s; S; V |-aa e => r1 / S1 ->
     ls = (l :: s) ->
@@ -62,11 +61,13 @@ Inductive analyze
     x <> x1 ->
     ml l2 = Some <{ (e1 <-* e2) @ l2 }> ->
     mf; ml; s; V; l2; e1 |_V_| S => r1 + S1 ->
-    mf; ml; S1; V; x: mf_l |_N_| r1 =>  r2 + S2 ->
+    mf; ml; S1; V; x: mf_l |_N_| r1 => r2 + S2 ->
     mf; ml; (l2 :: s); S; V |-aa x@l => r2 / S2
 (* TODO: add Stub rules *)
 
-with union_appl : myfun -> mylexpr -> sigma -> s_set -> v_set -> disj -> disj -> s_set -> Prop :=
+with union_appl
+  : myfun -> mylexpr -> sigma -> s_set -> v_set -> disj -> disj -> s_set -> Prop
+:=
   | UA_Nil : forall mf ml s S V, mf; ml; s; S; V |_A_| [] => [] + []
   (* go through every disjunct to union the result *)
   | UA_Cons : forall mf ml s S V x1 e1 l1 s1 r1s r2 S2 r0 S0 r0s S0s,
@@ -74,9 +75,11 @@ with union_appl : myfun -> mylexpr -> sigma -> s_set -> v_set -> disj -> disj ->
     mf; ml; s; S; V |_A_| r1s => r0s + S0s ->
     r2 = r0 ++ r0s ->
     S2 = S0 ++ S0s ->
-    mf; ml; s; S; V |_A_| <{ [ fun x1 *-> e1, l1, s1 ] }> :: r1s => r2 + S2
+    mf; ml; s; S; V |_A_| <fun x1 *-> e1, l1, s1> :: r1s => r2 + S2
 
-with union_stitch : myfun -> mylexpr -> sigma -> v_set -> nat -> lexpr -> s_set -> disj -> s_set -> Prop :=
+with union_stitch
+  : myfun -> mylexpr -> sigma -> v_set -> nat -> lexpr -> s_set -> disj -> s_set -> Prop
+:=
   | ST_Nil : forall mf ml s V e2 l', mf; ml; s; V; l'; e2 |_V_| [] => [] + []
   (* skip current stack s'' if its top frame isn't l' *)
   | ST_Cons_Skip : forall mf ml s V l' e2 s'' S r0s S0s,
@@ -94,16 +97,18 @@ with union_stitch : myfun -> mylexpr -> sigma -> v_set -> nat -> lexpr -> s_set 
     S1 = S0 ++ S0s ->
     mf; ml; s; V; l'; e2 |_V_| (s'' :: S) => r1 + S1
 
-with union_varnonlocal : myfun -> mylexpr -> s_set -> v_set -> expr -> nat -> disj -> disj -> s_set -> Prop :=
+with union_varnonlocal
+  : myfun -> mylexpr -> s_set -> v_set -> expr -> nat -> disj -> disj -> s_set -> Prop
+:=
   | UVN_Nil : forall mf ml S1 V x l1, mf; ml; S1; V; x: l1 |_N_| [] => [] + []
   (* go through every disjunct to union the result *)
   | UVN_Cons : forall mf ml S1 V x l1 x1 e s1 r1s r2 S2 r0' S0' r0's S0's,
     mf; ml; s1; S1; V |-aa x@l1 => r0' / S0' ->
-    mf; ml; S1; V; x: l1 |_N_| r1s =>  r0's + S0's ->
+    mf; ml; S1; V; x: l1 |_N_| r1s => r0's + S0's ->
     r2 = r0' ++ r0's ->
     S2 = S0' ++ S0's ->
     (* checking l1 is sufficient because we never relabel functions *)
-    mf; ml; S1; V; x: l1 |_N_| <{ [ fun x1 *-> e, l1, s1 ] }> :: r1s =>  r2 + S2
+    mf; ml; S1; V; x: l1 |_N_| <fun x1 *-> e, l1, s1> :: r1s => r2 + S2
 
   where "mf ; ml ; s ; S ; V '|-aa' e => rc / Sv" := (analyze mf ml s S V e rc Sv)
     and "mf ; ml ; s ; S ; V '|_A_|' r1 => r2 + S2" := (union_appl mf ml s S V r1 r2 S2)
@@ -154,9 +159,8 @@ Ltac solve_analyze :=
     | _ ++ _ => simpl; econstructor
     | [] => constructor
     end
-  | [|- _ <> _] => intro; discriminate
+  | [|- _ <> _] => discriminate
   | [|- _ = _] => reflexivity
-  | _ => idtac
   end.
 
 (* simple function value *)
@@ -165,7 +169,7 @@ Definition eg_val_mf := build_myfun eg_val.
 Definition eg_val_ml := build_mylexpr eg_val.
 
 Example eg_val_correct :
-  eg_val_mf; eg_val_ml; []; []; [] |-aa eg_val => [<{ [ fun X *-> X@0, 1, [] ] }>] / [].
+  eg_val_mf; eg_val_ml; []; []; [] |-aa eg_val => [<fun X *-> X@0, 1, []>] / [].
 Proof.
   apply A_Val.
 Qed.
@@ -177,19 +181,19 @@ Definition eg_loc_mf := build_myfun eg_loc.
 Definition eg_loc_ml := build_mylexpr eg_loc.
 
 Example eg_loc_correct :
-  eg_loc_mf; eg_loc_ml; []; []; [] |-aa eg_loc => [<{ [ fun Y *-> Y@2, 3, [] ] }>] / [].
+  eg_loc_mf; eg_loc_ml; []; []; [] |-aa eg_loc => [<fun Y *-> Y@2, 3, []>] / [].
 Proof.
   solve_analyze.
 Qed.
 
 (* verbose version for stepping through proof *)
 Example eg_loc_correct' :
-  eg_loc_mf; eg_loc_ml; []; []; [] |-aa eg_loc => [<{ [ fun Y *-> Y@2, 3, [] ] }>] / [].
-Proof.
-  eapply A_Appl; try reflexivity.
+  eg_loc_mf; eg_loc_ml; []; []; [] |-aa eg_loc => [<fun Y *-> Y@2, 3, []>] / [].
+Proof with try reflexivity.
+  eapply A_Appl...
   - apply A_Val.
   - eapply UA_Cons.
-    + eapply A_VarLocal; try reflexivity.
+    + eapply A_VarLocal...
       eapply ST_Cons.
       * reflexivity.
       * apply A_Val.
@@ -211,14 +215,14 @@ Definition eg_noloc_mf := build_myfun eg_noloc.
 Definition eg_noloc_ml := build_mylexpr eg_noloc.
 
 Example eg_noloc_correct :
-  eg_noloc_mf; eg_noloc_ml; []; []; [] |-aa eg_noloc => [<{ [ fun Z *-> Z@3, 4, [] ] }>] / [].
+  eg_noloc_mf; eg_noloc_ml; []; []; [] |-aa eg_noloc => [<fun Z *-> Z@3, 4, []>] / [].
 Proof.
   solve_analyze.
 Qed.
 
 (* verbose version for stepping through proof *)
 Example eg_noloc_correct' :
-  eg_noloc_mf; eg_noloc_ml; []; []; [] |-aa eg_noloc => [<{ [ fun Z *-> Z@3, 4, [] ] }>] / [].
+  eg_noloc_mf; eg_noloc_ml; []; []; [] |-aa eg_noloc => [<fun Z *-> Z@3, 4, []>] / [].
 Proof with try reflexivity.
   eapply A_Appl...
   - eapply A_Appl...
@@ -230,7 +234,7 @@ Proof with try reflexivity.
       * reflexivity.
   - eapply UA_Cons.
     + eapply A_VarNonLocal...
-      * intro. discriminate.
+      * discriminate.
       * eapply ST_Cons.
         -- reflexivity.
         -- eapply A_Appl...

--- a/formal/Abstract/Pure.v
+++ b/formal/Abstract/Pure.v
@@ -3,37 +3,37 @@ From DDE.Abstract Require Import Common.
 #[local] Open Scope lang_scope.
 
 Reserved Notation
-         "mf / ml / s / S '|-a' e => rv / Sv"
-         (at level 40, e custom lang at level 99, rv custom lang at level 99,
-          ml at next level, s at next level, S at next level, Sv constr).
+         "mf ; ml ; s ; S '|-a' e => rv / Sv"
+         (at level 40, e custom lang at level 99, rv at next level,
+          ml at next level, s at next level, S at next level, Sv at next level).
 
 Inductive analyze
   : myfun -> mylexpr -> sigma -> s_set -> lexpr -> res -> s_set -> Prop
 :=
   | A_Val : forall mf ml s S v l,
-    mf / ml / s / S |-a ($v)@l => [ v, l, s ] / S
+    mf; ml; s; S |-a ($v)@l => (<v, l, s>) / S
   | A_Appl : forall mf ml s S e1 e2 l rv Sv x e l1 s1 S1,
-    mf / ml / s / S |-a e1 => [ fun x *-> e, l1, s1 ] / S1 ->
-    mf / ml / prune_sigma2 (l :: s) / ((l :: s) :: S1) |-a e => rv / Sv ->
-    mf / ml / s / S |-a (e1 <-* e2) @ l => rv / Sv
+    mf; ml; s; S |-a e1 => <fun x *-> e, l1, s1> / S1 ->
+    mf; ml; prune_sigma2 (l :: s); ((l :: s) :: S1) |-a e => rv / Sv ->
+    mf; ml; s; S |-a (e1 <-* e2) @ l => rv / Sv
   (* TODO: should s' be universally/existentially quantified? *)
   | A_VarLocal : forall mf ml e1 e2 l' s S x l rv Sv mf_l e s',
     mf l = Some mf_l ->
     ml mf_l = Some <{ ($fun x *-> e) @ mf_l }> ->
     ml l' = Some <{ (e1 <-* e2) @ l' }> ->
     (exists s0, In s0 S /\ s0 = l' :: s ++ s') ->
-    mf / ml / (s ++ s') / S |-a e2 => rv / Sv ->
-    mf / ml / (l' :: s) / S |-a x@l => rv / Sv
+    mf; ml; (s ++ s'); S |-a e2 => rv / Sv ->
+    mf; ml; (l' :: s); S |-a x@l => rv / Sv
   | A_VarNonLocal : forall mf ml e1 e2 l2 s S x l rv Sv x1 e l1 s1 S1,
     mf l = Some l1 ->
     ml l1 = Some <{ ($fun x1 *-> e) @ l1 }> ->
     x <> x1 ->
     ml l2 = Some <{ (e1 <-* e2) @ l2 }> ->
-    mf / ml / s / S |-a e1 => [ fun x1 *-> e, l1, s1] / S1 ->
-    mf / ml / s1 / S1 |-a x@l1 => rv / Sv ->
-    mf / ml / (l2 :: s) / S |-a x@l => rv / Sv
+    mf; ml; s; S |-a e1 => <fun x1 *-> e, l1, s1> / S1 ->
+    mf; ml; s1; S1 |-a x@l1 => rv / Sv ->
+    mf; ml; (l2 :: s); S |-a x@l => rv / Sv
 
-  where "mf / ml / s / S '|-a' e => rv / Sv" := (analyze mf ml s S e rv Sv).
+  where "mf ; ml ; s ; S '|-a' e => rv / Sv" := (analyze mf ml s S e rv Sv).
 
 Definition Self : string := "self".
 
@@ -47,7 +47,7 @@ Definition eg_rec_ml := build_mylexpr eg_rec.
 (* TODO: find examples *)
 Theorem analyze_nondeterministic :
   ~ forall mf ml s S e Sv rv1 rv2,
-      mf / ml / s / S |-a e => rv1 / Sv ->
-      mf / ml / s / S |-a e => rv2 / Sv ->
+      mf; ml; s; S |-a e => rv1 / Sv ->
+      mf; ml; s; S |-a e => rv2 / Sv ->
       rv1 = rv2.
 Admitted.

--- a/formal/Abstract/Pure.v
+++ b/formal/Abstract/Pure.v
@@ -3,7 +3,7 @@ From DDE.Abstract Require Import Common.
 #[local] Open Scope lang_scope.
 
 Reserved Notation
-         "mf ; ml ; s ; S '|-a' e => rv / Sv"
+         "mf / ml / s / S '|-a' e => rv / Sv"
          (at level 40, e custom lang at level 99, rv at next level,
           ml at next level, s at next level, S at next level, Sv at next level).
 
@@ -11,29 +11,29 @@ Inductive analyze
   : myfun -> mylexpr -> sigma -> s_set -> lexpr -> res -> s_set -> Prop
 :=
   | A_Val : forall mf ml s S v l,
-    mf; ml; s; S |-a ($v)@l => (<v, l, s>) / S
+    mf / ml / s / S |-a ($v)@l => (<v, l, s>) / S
   | A_Appl : forall mf ml s S e1 e2 l rv Sv x e l1 s1 S1,
-    mf; ml; s; S |-a e1 => <fun x *-> e, l1, s1> / S1 ->
-    mf; ml; prune_sigma2 (l :: s); ((l :: s) :: S1) |-a e => rv / Sv ->
-    mf; ml; s; S |-a (e1 <-* e2) @ l => rv / Sv
+    mf / ml / s / S |-a e1 => <fun x *-> e, l1, s1> / S1 ->
+    mf / ml / prune_sigma2 (l :: s) / ((l :: s) :: S1) |-a e => rv / Sv ->
+    mf / ml / s / S |-a (e1 <-* e2) @ l => rv / Sv
   (* TODO: should s' be universally/existentially quantified? *)
   | A_VarLocal : forall mf ml e1 e2 l' s S x l rv Sv mf_l e s',
     mf l = Some mf_l ->
     ml mf_l = Some <{ ($fun x *-> e) @ mf_l }> ->
     ml l' = Some <{ (e1 <-* e2) @ l' }> ->
     (exists s0, In s0 S /\ s0 = l' :: s ++ s') ->
-    mf; ml; (s ++ s'); S |-a e2 => rv / Sv ->
-    mf; ml; (l' :: s); S |-a x@l => rv / Sv
+    mf / ml / (s ++ s') / S |-a e2 => rv / Sv ->
+    mf / ml / (l' :: s) / S |-a x@l => rv / Sv
   | A_VarNonLocal : forall mf ml e1 e2 l2 s S x l rv Sv x1 e l1 s1 S1,
     mf l = Some l1 ->
     ml l1 = Some <{ ($fun x1 *-> e) @ l1 }> ->
     x <> x1 ->
     ml l2 = Some <{ (e1 <-* e2) @ l2 }> ->
-    mf; ml; s; S |-a e1 => <fun x1 *-> e, l1, s1> / S1 ->
-    mf; ml; s1; S1 |-a x@l1 => rv / Sv ->
-    mf; ml; (l2 :: s); S |-a x@l => rv / Sv
+    mf / ml / s / S |-a e1 => <fun x1 *-> e, l1, s1> / S1 ->
+    mf / ml / s1 / S1 |-a x@l1 => rv / Sv ->
+    mf / ml / (l2 :: s) / S |-a x@l => rv / Sv
 
-  where "mf ; ml ; s ; S '|-a' e => rv / Sv" := (analyze mf ml s S e rv Sv).
+  where "mf / ml / s / S '|-a' e => rv / Sv" := (analyze mf ml s S e rv Sv).
 
 Definition Self : string := "self".
 
@@ -47,7 +47,7 @@ Definition eg_rec_ml := build_mylexpr eg_rec.
 (* TODO: find examples *)
 Theorem analyze_nondeterministic :
   ~ forall mf ml s S e Sv rv1 rv2,
-      mf; ml; s; S |-a e => rv1 / Sv ->
-      mf; ml; s; S |-a e => rv2 / Sv ->
+      mf / ml / s / S |-a e => rv1 / Sv ->
+      mf / ml / s / S |-a e => rv2 / Sv ->
       rv1 = rv2.
 Admitted.

--- a/formal/Common/Lang.v
+++ b/formal/Common/Lang.v
@@ -46,9 +46,11 @@ Notation "$ v" :=
 Notation "e @ l" :=
   (Lexpr e l)
     (in custom lang at level 15) : lang_scope.
-Notation "[ v , l , s ]" :=
+
+Notation "< v , l , s >" :=
   (Res v l s)
-    (in custom lang at level 99, v at next level, l at next level, s constr) : lang_scope.
+    (at level 39, v custom lang at level 99,
+      l at next level, s at next level) : lang_scope.
 
 #[local] Open Scope lang_scope.
 
@@ -78,13 +80,13 @@ Fixpoint assn (e : expr) (l : nat) : lexpr * nat :=
 
 (* assn will in practice only be used on expr's with no lexpr subcomponents *)
 Inductive assn_prac : expr -> nat -> nat -> Prop :=
-  | assn_prac_ident : forall x l,
+  | AP_Ident : forall x l,
     assn_prac (Ident x) l (S l)
-  | assn_prac_appl : forall e1 e2 l l1' l2',
+  | AP_Appl : forall e1 e2 l l1' l2',
     assn_prac e1 l l1' ->
     assn_prac e2 l1' l2' ->
     assn_prac <{ e1 <- e2 }> l (S l2')
-  | assn_prac_val : forall v l l' x e',
+  | AP_Val : forall v l l' x e',
     v = <{ fun x -> e' }> ->
     assn_prac e' l l' ->
     assn_prac <{ $v }> l (S l').
@@ -101,13 +103,13 @@ Proof.
     destruct (assn e1 l).
     simpl in IHassn_prac1. rewrite IHassn_prac1 in IHassn_prac2.
     destruct (assn e2 n).
-    simpl in *. subst. reflexivity.
+    subst. reflexivity.
   - rewrite H. simpl.
     destruct (assn e' l).
-    simpl in *. subst. reflexivity.
+    subst. reflexivity.
 Qed.
 
-Definition to_lexpr (e : expr) := fst (assn e 0).
+Definition to_lexpr (e : expr) : lexpr := fst (assn e 0).
 
 Example sample_fun := to_lexpr <{ $fun X -> X }>.
 Example sample_fun' := to_lexpr <{ $fun X -> $fun Y -> X }>.
@@ -117,7 +119,7 @@ Example sample_fun'' := to_lexpr <{ $fun X -> (X <- X) }>.
 Example sample_appl := to_lexpr <{ ($fun X -> X) <- ($fun X -> X) }>.
 Example sample_appl' := to_lexpr <{ X <- X }>.
 (* Compute sample_appl'. *)
-Example sample_res := <{ [ fun X *-> X@0, 1, 2 :: [] ] }>.
+Example sample_res := < fun X *-> X@0, 1, (2 :: []) >.
 
 Definition myfun : Type := partial_map nat nat.
 Definition mylexpr : Type := partial_map nat lexpr.

--- a/formal/Common/Tactics.v
+++ b/formal/Common/Tactics.v
@@ -1,0 +1,8 @@
+Ltac invert H := inversion H; subst; clear H.
+
+Ltac inject_all :=
+  repeat match goal with
+    H1 : ?E = _,
+    H2 : ?E = _
+    |- _ => rewrite H1 in H2; invert H2
+  end.

--- a/formal/Common/dune
+++ b/formal/Common/dune
@@ -1,3 +1,3 @@
 (coq.theory
  (name DDE.Common)
- (modules Maps Lang))
+ (modules Maps Lang Tactics))

--- a/formal/Concrete/Core.v
+++ b/formal/Concrete/Core.v
@@ -3,38 +3,38 @@ From DDE.Common Require Import Lang Tactics.
 #[local] Open Scope lang_scope.
 
 (* custom syntax for evaluation, mirroring the written syntax
-   as much as possible. Uses ';' instead of ',' so notation doesn't
+   as much as possible. Uses ' /' instead of ',' so notation doesn't
    clash with that of Ltac's match goal. *)
 Reserved Notation
-         "mf ; ml ; s |- e => r"
+         "mf / ml / s |- e => r"
          (at level 40, e custom lang at level 99, r at next level,
           ml at next level, s at next level).
 
 (* logic for DDE's concrete lambda calculus operational semantics *)
 Inductive eval : myfun -> mylexpr -> sigma -> lexpr -> res -> Prop :=
   | E_Val : forall s v l mf ml,
-    mf; ml; s |- ($v)@l => <v, l, s>
+    mf / ml / s |- ($v)@l => <v, l, s>
   (* TODO: forall sound? *)
   | E_Appl : forall e1 e2 l s r x e l1 s1 mf ml,
-    mf; ml; s |- e1 => <fun x *-> e, l1, s1> ->
-    mf; ml; l :: s |- e => r ->
-    mf; ml; s |- (e1 <-* e2) @ l => r
+    mf / ml / s |- e1 => <fun x *-> e, l1, s1> ->
+    mf / ml / l :: s |- e => r ->
+    mf / ml / s |- (e1 <-* e2) @ l => r
   | E_VarLocal : forall x l s r mf ml e1 e2 l' e mf_l,
     ml l' = Some <{ (e1 <-* e2) @ l' }> ->
     mf l = Some mf_l ->
     ml mf_l = Some <{ ($fun x *-> e) @ mf_l }> ->
-    mf; ml; s |- e2 => r ->
-    mf; ml; (l' :: s) |- x@l => r
+    mf / ml / s |- e2 => r ->
+    mf / ml / (l' :: s) |- x@l => r
   | E_VarNonLocal : forall x l s r mf ml e1 e2 l2 e l1 x1 s1,
     mf l = Some l1 ->
     ml l1 = Some <{ ($fun x1 *-> e) @ l1 }> ->
     x <> x1 ->
     ml l2 = Some <{ (e1 <-* e2) @ l2 }> ->
-    mf; ml; s |- e1 => <fun x1 *-> e, l1, s1> ->
-    mf; ml; s1 |- x@l1 => r ->
-    mf; ml; (l2 :: s) |- x@l => r
+    mf / ml / s |- e1 => <fun x1 *-> e, l1, s1> ->
+    mf / ml / s1 |- x@l1 => r ->
+    mf / ml / (l2 :: s) |- x@l => r
 
-  where "mf ; ml ; s |- e => r" := (eval mf ml s e r).
+  where "mf / ml / s |- e => r" := (eval mf ml s e r).
 
 Definition id_val := to_lexpr <{ $fun X -> X }>.
 Definition id_val_mf := build_myfun id_val.
@@ -42,7 +42,7 @@ Definition id_val_ml := build_mylexpr id_val.
 
 (* simple value *)
 Example eg_val_correct :
-  id_val_mf; id_val_ml; [] |- id_val => <fun X *-> X@0, 1, []>.
+  id_val_mf / id_val_ml / [] |- id_val => <fun X *-> X@0, 1, []>.
 Proof.
   apply E_Val.
 Qed.
@@ -56,7 +56,7 @@ Definition eg_loc_ml := build_mylexpr eg_loc.
    so that the proof can be better traced to see what's happening. Proof
    scripts can be almost entirely automated in our logic. *)
 Example eg_loc_correct :
-  eg_loc_mf; eg_loc_ml; [] |- eg_loc => <fun Y *-> Y@2, 3, []>.
+  eg_loc_mf / eg_loc_ml / [] |- eg_loc => <fun Y *-> Y@2, 3, []>.
 Proof.
   eapply E_Appl.
   - apply E_Val.
@@ -71,7 +71,7 @@ Definition eg_noloc_ml := build_mylexpr eg_noloc.
 
 (* non-local variable lookup *)
 Example eg_noloc_correct :
-  eg_noloc_mf; eg_noloc_ml; [] |- eg_noloc => <fun Z *-> Z@3, 4, []>.
+  eg_noloc_mf / eg_noloc_ml / [] |- eg_noloc => <fun Z *-> Z@3, 4, []>.
 Proof with try reflexivity.
   eapply E_Appl.
   - eapply E_Appl.
@@ -89,7 +89,7 @@ Qed.
 
 (* bad non-local variable lookup *)
 Example eg_noloc_bad :
-  ~ eg_noloc_mf; eg_noloc_ml; [] |- eg_noloc => <fun M *-> M@6, 7, []>.
+  ~ eg_noloc_mf / eg_noloc_ml / [] |- eg_noloc => <fun M *-> M@6, 7, []>.
 Proof.
   intro Contra. invert Contra.
   invert H6. invert H8. invert H9. invert H7.
@@ -104,8 +104,8 @@ Proof.
 Qed.
 
 Theorem eval_deterministic : forall mf ml s e r1 r2,
-  mf; ml; s |- e => r1 ->
-  mf; ml; s |- e => r2 ->
+  mf / ml / s |- e => r1 ->
+  mf / ml / s |- e => r2 ->
   r1 = r2.
 Proof.
   intros. generalize dependent r2.

--- a/formal/Concrete/Core.v
+++ b/formal/Concrete/Core.v
@@ -1,40 +1,40 @@
-From DDE.Common Require Import Lang.
+From DDE.Common Require Import Lang Tactics.
 
 #[local] Open Scope lang_scope.
 
 (* custom syntax for evaluation, mirroring the written syntax
-   as much as possible. Uses '/' instead of ',' so notation doesn't
+   as much as possible. Uses ';' instead of ',' so notation doesn't
    clash with that of Ltac's match goal. *)
 Reserved Notation
-         "mf / ml / s |- e => r"
-         (at level 40, e custom lang at level 99, r custom lang at level 99,
+         "mf ; ml ; s |- e => r"
+         (at level 40, e custom lang at level 99, r at next level,
           ml at next level, s at next level).
 
 (* logic for DDE's concrete lambda calculus operational semantics *)
-Inductive eval : lexpr -> sigma -> res -> myfun -> mylexpr -> Prop :=
+Inductive eval : myfun -> mylexpr -> sigma -> lexpr -> res -> Prop :=
   | E_Val : forall s v l mf ml,
-    mf / ml / s |- ($v)@l => [ v, l, s ]
+    mf; ml; s |- ($v)@l => <v, l, s>
   (* TODO: forall sound? *)
   | E_Appl : forall e1 e2 l s r x e l1 s1 mf ml,
-    mf / ml / s |- e1 => [ fun x *-> e, l1, s1 ] ->
-    mf / ml / l :: s |- e => r ->
-    mf / ml / s |- (e1 <-* e2) @ l => r
+    mf; ml; s |- e1 => <fun x *-> e, l1, s1> ->
+    mf; ml; l :: s |- e => r ->
+    mf; ml; s |- (e1 <-* e2) @ l => r
   | E_VarLocal : forall x l s r mf ml e1 e2 l' e mf_l,
     ml l' = Some <{ (e1 <-* e2) @ l' }> ->
     mf l = Some mf_l ->
     ml mf_l = Some <{ ($fun x *-> e) @ mf_l }> ->
-    mf / ml / s |- e2 => r ->
-    mf / ml / (l' :: s) |- x@l => r
+    mf; ml; s |- e2 => r ->
+    mf; ml; (l' :: s) |- x@l => r
   | E_VarNonLocal : forall x l s r mf ml e1 e2 l2 e l1 x1 s1,
     mf l = Some l1 ->
     ml l1 = Some <{ ($fun x1 *-> e) @ l1 }> ->
     x <> x1 ->
     ml l2 = Some <{ (e1 <-* e2) @ l2 }> ->
-    mf / ml / s |- e1 => [ fun x1 *-> e, l1, s1 ] ->
-    mf / ml / s1 |- x@l1 => r ->
-    mf / ml / (l2 :: s) |- x@l => r
+    mf; ml; s |- e1 => <fun x1 *-> e, l1, s1> ->
+    mf; ml; s1 |- x@l1 => r ->
+    mf; ml; (l2 :: s) |- x@l => r
 
-  where "mf / ml / s |- e => r" := (eval e s r mf ml).
+  where "mf ; ml ; s |- e => r" := (eval mf ml s e r).
 
 Definition id_val := to_lexpr <{ $fun X -> X }>.
 Definition id_val_mf := build_myfun id_val.
@@ -42,7 +42,7 @@ Definition id_val_ml := build_mylexpr id_val.
 
 (* simple value *)
 Example eg_val_correct :
-  id_val_mf / id_val_ml / [] |- id_val => [ fun X *-> X@0, 1, [] ].
+  id_val_mf; id_val_ml; [] |- id_val => <fun X *-> X@0, 1, []>.
 Proof.
   apply E_Val.
 Qed.
@@ -56,15 +56,12 @@ Definition eg_loc_ml := build_mylexpr eg_loc.
    so that the proof can be better traced to see what's happening. Proof
    scripts can be almost entirely automated in our logic. *)
 Example eg_loc_correct :
-  eg_loc_mf / eg_loc_ml / [] |- eg_loc => [ fun Y *-> Y@2, 3, [] ].
+  eg_loc_mf; eg_loc_ml; [] |- eg_loc => <fun Y *-> Y@2, 3, []>.
 Proof.
   eapply E_Appl.
   - apply E_Val.
-  - eapply E_VarLocal.
-    + unfold eg_loc_ml, eg_loc. autounfold. reflexivity.
-    + unfold eg_loc_mf, eg_loc. autounfold. reflexivity.
-    + unfold eg_loc_ml, eg_loc. autounfold. reflexivity.
-    + apply E_Val.
+  - eapply E_VarLocal; try reflexivity.
+    apply E_Val.
 Qed.
 
 Definition eg_noloc :=
@@ -74,103 +71,56 @@ Definition eg_noloc_ml := build_mylexpr eg_noloc.
 
 (* non-local variable lookup *)
 Example eg_noloc_correct :
-  eg_noloc_mf / eg_noloc_ml / [] |- eg_noloc => [ fun Z *-> Z@3, 4, [] ].
-Proof.
+  eg_noloc_mf; eg_noloc_ml; [] |- eg_noloc => <fun Z *-> Z@3, 4, []>.
+Proof with try reflexivity.
   eapply E_Appl.
   - eapply E_Appl.
     + apply E_Val.
     + apply E_Val.
-  - eapply E_VarNonLocal.
-    + reflexivity.
-    + reflexivity.
+  - eapply E_VarNonLocal...
     + discriminate.
-    + reflexivity.
     (* N.B. that we re-do the application here, as expected from the rules *)
     + eapply E_Appl.
       * apply E_Val.
       * apply E_Val.
-    + eapply E_VarLocal.
-      * reflexivity.
-      * reflexivity.
-      * reflexivity.
+    + eapply E_VarLocal...
       * apply E_Val.
 Qed.
 
-(* TODO: don't need this; just invert *)
-Ltac map_lookup mymap prog :=
-  match goal with
-    H : mymap _ = _
-    |- _ => unfold mymap, prog in H; autounfold in H; simpl in H;
-            injection H as H; subst
-  end.
-
 (* bad non-local variable lookup *)
 Example eg_noloc_bad :
-  ~ eg_noloc_mf / eg_noloc_ml / [] |- eg_noloc => [ fun M *-> M@6, 7, [] ].
+  ~ eg_noloc_mf; eg_noloc_ml; [] |- eg_noloc => <fun M *-> M@6, 7, []>.
 Proof.
-  intro contra.
-  inversion contra. subst. clear contra.
-  inversion H6. subst. clear H6.
-  inversion H8. subst. clear H8.
-  inversion H9. subst. clear H9.
-  inversion H7; subst; clear H7.
-  (* E_VarLocal *)
-  - map_lookup eg_noloc_mf eg_noloc.
-    map_lookup eg_noloc_ml eg_noloc.
-    discriminate H9.
-  (* E_VarNonLocal *)
-  - map_lookup eg_noloc_ml eg_noloc.
-    map_lookup eg_noloc_mf eg_noloc.
-    map_lookup eg_noloc_ml eg_noloc.
-    inversion H11. subst. clear H11.
-    inversion H7. subst. clear H7.
-    inversion H8. subst. clear H8.
-    inversion H12; subst; clear H12.
-    (* E_VarLocal *)
-    + map_lookup eg_noloc_ml eg_noloc.
-      map_lookup eg_noloc_mf eg_noloc.
-      map_lookup eg_noloc_ml eg_noloc.
+  intro Contra. invert Contra.
+  invert H6. invert H8. invert H9. invert H7.
+  - (* E_VarLocal *) invert H5. invert H6. invert H9.
+  - (* E_VarNonLocal *) invert H3. invert H4. invert H9.
+    invert H11. invert H6. invert H7.
+    invert H12.
+    + (* E_VarLocal *) invert H5. invert H6. invert H9.
       inversion H10.
-    (* E_VarNonLocal *)
-    + map_lookup eg_noloc_ml eg_noloc.
-      map_lookup eg_noloc_mf eg_noloc.
-      map_lookup eg_noloc_ml eg_noloc.
+    + (* E_VarNonLocal *) invert H3. invert H4.
       contradiction.
 Qed.
 
-Ltac injection_subst :=
-  match goal with
-    H1 : ?E = _,
-    H2 : ?E = _
-    |- _ => rewrite H1 in H2; injection H2 as H2; subst; clear H1
-  end.
-
 Theorem eval_deterministic : forall mf ml s e r1 r2,
-  mf / ml / s |- e => r1 ->
-  mf / ml / s |- e => r2 ->
+  mf; ml; s |- e => r1 ->
+  mf; ml; s |- e => r2 ->
   r1 = r2.
 Proof.
-  intros. generalize dependent r2. induction H; intros.
-  (* E_Val *)
-  - inversion H0. subst. reflexivity.
-  (* E_Appl *)
-  - inversion H1. subst. clear H1.
-    apply IHeval1 in H9. injection H9 as H9. subst.
+  intros. generalize dependent r2.
+  induction H; intros.
+  - (* E_Val *) invert H0. reflexivity.
+  - (* E_Appl *) invert H1.
+    apply IHeval1 in H9. invert H9. subst.
     apply IHeval2 in H10. assumption.
-  (* E_VarLocal *)
-  - inversion H3; subst; clear H3.
-    (* E_VarLocal *)
-    + repeat injection_subst. clear H2.
+  - (* E_VarLocal *) invert H3.
+    + (* E_VarLocal *) inject_all.
       apply IHeval in H14. assumption.
-    (* E_VarNonLocal *)
-    + congruence.
-  (* E_VarNonLocal *)
-  - inversion H5; subst; clear H5.
-    (* E_VarLocal *)
-    + congruence.
-    (* E_VarNonLocal *)
-    + repeat injection_subst.
-      clear H3. clear H4.
-      apply IHeval1 in H17. injection H17 as H17. subst.
+    + (* E_VarNonLocal *) congruence.
+  - (* E_VarNonLocal *) invert H5.
+    + (* E_VarLocal *) congruence.
+    + (* E_VarNonLocal *) inject_all.
+      apply IHeval1 in H17. invert H17.
       apply IHeval2 in H18. assumption.
 Qed.

--- a/formal/Concrete/Env.v
+++ b/formal/Concrete/Env.v
@@ -29,9 +29,10 @@ Notation "e1 <- e2" :=
 Notation "$ v" :=
   (Val v)
     (in custom lang at level 25) : lang_scope.
-Notation "[ v , env ]" :=
+
+Notation "< v , env >" :=
   (Res v env)
-    (in custom lang at level 15, v at next level, env constr) : lang_scope.
+    (at level 39, v custom lang at level 99, env at next level) : lang_scope.
 
 #[local] Open Scope lang_scope.
 
@@ -41,37 +42,37 @@ Definition Z : string := "z".
 Definition M : string := "m".
 Definition N : string := "n".
 
-Example sample_res := <{ [ fun Y -> Y, X |-> <{ [ fun Y -> Y, empty] }> ] }>.
+Example sample_res := <fun Y -> Y, (X |-> <fun Y -> Y, empty>) >.
 
 Reserved Notation
-         "env |- e => r"
-         (at level 40, e custom lang at level 99, env constr, r custom lang at level 99).
+         "env '|-e' e => r"
+         (at level 40, e custom lang at level 99, env constr, r at next level).
 
 Inductive eval : expr -> env -> res -> Prop :=
   | E_Val : forall E v,
-    E |- $v => [ v, E ]
+    E |-e $v => <v, E>
   | E_Appl : forall E e1 e2 r x e (E1 : partial_map string res) r2,
-    E |- e1 => [ fun x -> e, E1 ] ->
-    E |- e2 => r2 ->
-    (x |-> r2; E1) |- e => r ->
-    E |- e1 <- e2 => r
+    E |-e e1 => <fun x -> e, E1> ->
+    E |-e e2 => r2 ->
+    (x |-> r2; E1) |-e e => r ->
+    E |-e e1 <- e2 => r
   | E_Var : forall (E : partial_map string res) x r,
     E x = Some r ->
-    E |- x => r
+    E |-e x => r
 
-  where "env |- e => r" := (eval e env r).
+  where "env '|-e' e => r" := (eval e env r).
 
 Example eg_val_correct :
-  empty |- $fun X -> X => [ fun X -> X, empty ].
+  empty |-e $fun X -> X => <fun X -> X, empty>.
 Proof.
   apply E_Val.
 Qed.
 
 Example eg_app_correct :
-  empty |- $fun X -> X <- $fun Y -> Y => [ fun Y -> Y, empty ].
+  empty |-e $fun X -> X <- $fun Y -> Y => <fun Y -> Y, empty>.
 Proof.
   eapply E_Appl.
   - apply E_Val.
   - apply E_Val.
-  - apply E_Var. unfold update, t_update. simpl. reflexivity.
+  - apply E_Var. reflexivity.
 Qed.

--- a/formal/README.md
+++ b/formal/README.md
@@ -12,8 +12,8 @@ Current progress:
   - [x] all-paths
     - [ ] deterministic
   - [ ] standard
-  - [ ] Soundness with respect to concrete semantics
-  - [ ] Greater precision of demand-driven semantics
+  - [ ] soundness with respect to concrete semantics
+  - [ ] greater precision of demand-driven semantics
 
 ## Set up
 
@@ -21,7 +21,7 @@ Follow the [official instructions](https://coq.inria.fr/download) to install Coq
 
 ## Develop
 
-`dune build` or `dune build formal` from the repo root, then use your preferred
+`dune build`, or `dune build formal` from the repo root, then use your preferred
 IDE to step through the scripts.
 
 If you're using VSCode, I recommend installing the


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #62
* #66
* __->__ #65

This commit includes the following quality-of-life improvements:

- Dissociate results from custom language syntax so they don't need to
wrapped in `<{ ... }>`. This declutters various definitions.
- Shorten proof scripts in Concrete/Core.v using improved custom
tactics.
- Extract those custom tactics to a separate module to be shared with
other semantics.

Test plan:

`dune build formal` and see that everything compiles.