### PR TITLE
[Formal] Major fixes to AllPaths.v

### DIFF
--- a/formal/Abstract/AllPaths.v
+++ b/formal/Abstract/AllPaths.v
@@ -1,8 +1,10 @@
 From DDE.Abstract Require Import Common.
+From DDE.Common Require Import Tactics.
 
-(* TODO: use set library *)
-(* a set of labeled expression, stack pairs to stub cycles *)
-Definition v_set : Type := list (lexpr * sigma).
+Definition V_state : Type := lexpr * sigma.
+(* set of labeled expression + stack pairs to stub cycles *)
+Definition V_set : Type := set V_state.
+Definition empty_V : V_set := @empty_set V_state.
 
 (* a disjunction of possible analysis results *)
 Definition disj : Type := list res.
@@ -10,110 +12,112 @@ Definition disj : Type := list res.
 #[local] Open Scope lang_scope.
 
 Reserved Notation
-         "mf ; ml ; s ; S ; V '|-aa' e => rc / Sv"
+         "mf / ml / s / S / V '|-aa' e => rc / Sv"
          (at level 40, e custom lang at level 99, rc at next level,
           ml at next level, s at next level, S at next level, V at next level).
           
 (* union operation seen in Application *)
 Reserved Notation
-         "mf ; ml ; s ; S ; V '|_A_|' r1 => r2 + S2"
+         "mf / ml / s / S / V '|_A_|' r1 => r2 + S2"
          (at level 40, r1 at level 99,
           ml at next level, s at next level, S at next level, V at next level,
           r2 at next level).
 
 (* stack stitching union operation *)
 Reserved Notation
-         "mf ; ml ; s ; V ; l' ; e2 '|_V_|' S => r2 + S2"
-         (at level 40, S at level 99, e2 custom lang at level 99,
-          ml at next level, s at next level, V at next level, l' at next level,
-          r2 at next level).
+         "mf / ml / s / S / V / l' / e2 '|_V_|' S' => r2 + S2"
+         (at level 40, S' at level 99, e2 custom lang at level 99,
+          ml at next level, s at next level, S at next level, V at next level,
+          l' at next level, r2 at next level).
 
-(* TODO: use better syntax to distinguish from above *)
 (* union operation seen in Var Non-Local *)
 Reserved Notation
-         "mf ; ml ; S ; V ; x : l1 '|_N_|' r1 => r2 + S2"
+         "mf / ml / S / V / x / l1 '|_N_|' r1 => r2 + S2"
          (at level 40, r1 at level 99,
           ml at next level, S at next level, V at next level,
           x at next level, l1 at next level,
           r2 at next level).
 
 Inductive analyze
-  : myfun -> mylexpr -> sigma -> s_set -> v_set -> lexpr -> disj -> s_set -> Prop
+  : myfun -> mylexpr -> sigma -> S_set -> V_set -> lexpr -> disj -> S_set -> Prop
 :=
   | A_Val : forall mf ml s S V v l,
-    mf; ml; s; S; V |-aa ($v)@l => [<v, l, s>] / S
+    mf / ml / s / S / V |-aa ($v)@l => [<v, l, s>] / S
   | A_Appl : forall mf ml s S V e e' l r2 S2 r1 S1 ls ls_pruned,
-    mf; ml; s; S; V |-aa e => r1 / S1 ->
+    mf / ml / s / S / V |-aa e => r1 / S1 ->
     ls = (l :: s) ->
     ls_pruned = prune_sigma2 ls ->
-    mf; ml; ls_pruned; (ls :: S); ((e, ls_pruned) :: V) |_A_| r1 => r2 + S2 ->
-    mf; ml; s; S; V |-aa (e <-* e') @ l => r2 / S2
+    mf / ml / ls_pruned / (ls ~> S1) / ((e, ls_pruned) ~> V) |_A_| r1 => r2 + S2 ->
+    mf / ml / s / S / V |-aa (e <-* e') @ l => r2 / S2
   | A_VarLocal : forall mf ml s0 S V x l r1 S1 l' s mf_l e e1 e2,
     s0 = (l' :: s) ->
     mf l = Some mf_l ->
     ml mf_l = Some <{ ($fun x *-> e) @ mf_l }> ->
     ml l' = Some <{ (e1 <-* e2) @ l' }> ->
-    mf; ml; s; ((e, s0) :: V); l'; e2 |_V_| S => r1 + S1 ->
-    mf; ml; s0; S; V |-aa x@l => r1 / S1
+    mf / ml / s / S / ((e, s0) ~> V) / l' / e2 |_V_| S => r1 + S1 ->
+    mf / ml / s0 / S / V |-aa x@l => r1 / S1
   | A_VarNonLocal : forall mf ml l2 s S V x l r2 S2 mf_l x1 e e1 e2 r1 S1,
     mf l = Some mf_l ->
     ml mf_l = Some <{ ($fun x1 *-> e) @ mf_l }> ->
     x <> x1 ->
     ml l2 = Some <{ (e1 <-* e2) @ l2 }> ->
-    mf; ml; s; V; l2; e1 |_V_| S => r1 + S1 ->
-    mf; ml; S1; V; x: mf_l |_N_| r1 => r2 + S2 ->
-    mf; ml; (l2 :: s); S; V |-aa x@l => r2 / S2
+    mf / ml / s / S / V / l2 / e1 |_V_| S => r1 + S1 ->
+    mf / ml / S1 / V / x / mf_l |_N_| r1 => r2 + S2 ->
+    mf / ml / (l2 :: s) / S / V |-aa x@l => r2 / S2
 (* TODO: add Stub rules *)
 
 with union_appl
-  : myfun -> mylexpr -> sigma -> s_set -> v_set -> disj -> disj -> s_set -> Prop
+  : myfun -> mylexpr -> sigma -> S_set -> V_set -> disj -> disj -> S_set -> Prop
 :=
-  | UA_Nil : forall mf ml s S V, mf; ml; s; S; V |_A_| [] => [] + []
+  | UA_Nil : forall mf ml s S V, mf / ml / s / S / V |_A_| [] => [] + empty_S
   (* go through every disjunct to union the result *)
   | UA_Cons : forall mf ml s S V x1 e1 l1 s1 r1s r2 S2 r0 S0 r0s S0s,
-    mf; ml; s; S; V |-aa e1 => r0 / S0 ->
-    mf; ml; s; S; V |_A_| r1s => r0s + S0s ->
+    mf / ml / s / S / V |-aa e1 => r0 / S0 ->
+    mf / ml / s / S / V |_A_| r1s => r0s + S0s ->
     r2 = r0 ++ r0s ->
-    S2 = S0 ++ S0s ->
-    mf; ml; s; S; V |_A_| <fun x1 *-> e1, l1, s1> :: r1s => r2 + S2
+    S2 = S0 |_| S0s ->
+    mf / ml / s / S / V |_A_| <fun x1 *-> e1, l1, s1> :: r1s => r2 + S2
 
 with union_stitch
-  : myfun -> mylexpr -> sigma -> v_set -> nat -> lexpr -> s_set -> disj -> s_set -> Prop
+  : myfun -> mylexpr -> sigma -> S_set -> V_set -> nat -> lexpr -> S_set -> disj -> S_set -> Prop
 :=
-  | ST_Nil : forall mf ml s V e2 l', mf; ml; s; V; l'; e2 |_V_| [] => [] + []
+  | ST_Nil : forall mf ml s S V e2 l',
+    mf / ml / s / S / V / l' / e2 |_V_| empty_S => [] + empty_S
   (* skip current stack s'' if its top frame isn't l' *)
-  | ST_Cons_Skip : forall mf ml s V l' e2 s'' S r0s S0s,
-    s'' = [] \/ (forall l'' s', l'' <> l' /\ s'' = l'' :: s') ->
+  | ST_Cons_Skip : forall mf ml s S V l' e2 S' r0s S0s s'',
+    s'' ? S' ->
+    (forall l'' s', s'' = l'' :: s' -> l'' <> l') ->
     (* go through the rest of the stacks *)
-    mf; ml; s; V; l'; e2 |_V_| S => r0s + S0s ->
-    mf; ml; s; V; l'; e2 |_V_| (s'' :: S) => r0s + S0s
+    mf / ml / s / S / V / l' / e2 |_V_| S' \ s'' => r0s + S0s ->
+    mf / ml / s / S / V / l' / e2 |_V_| S' => r0s + S0s
   (* matching stack to execute and union with *)
-  | ST_Cons : forall mf ml s V l' e2 s'' S r1 S1 s' r0 S0 r0s S0s,
+  | ST_Cons : forall mf ml s S V l' e2 s'' S' r1 S1 s' r0 S0 r0s S0s,
+    s'' ? S' ->
     (* a match! *)
     s'' = l' :: s ++ s' ->
-    mf; ml; (s ++ s'); S; V |-aa e2 => r0 / S0 ->
-    mf; ml; s; V; l'; e2 |_V_| S => r0s + S0s ->
+    mf / ml / (s ++ s') / S / V |-aa e2 => r0 / S0 ->
+    mf / ml / s / S / V / l' / e2 |_V_| S' \ s'' => r0s + S0s ->
     r1 = r0 ++ r0s ->
-    S1 = S0 ++ S0s ->
-    mf; ml; s; V; l'; e2 |_V_| (s'' :: S) => r1 + S1
+    S1 = S0 |_| S0s ->
+    mf / ml / s / S / V / l' / e2 |_V_| S' => r1 + S1
 
 with union_varnonlocal
-  : myfun -> mylexpr -> s_set -> v_set -> expr -> nat -> disj -> disj -> s_set -> Prop
+  : myfun -> mylexpr -> S_set -> V_set -> expr -> nat -> disj -> disj -> S_set -> Prop
 :=
-  | UVN_Nil : forall mf ml S1 V x l1, mf; ml; S1; V; x: l1 |_N_| [] => [] + []
+  | UVN_Nil : forall mf ml S1 V x l1, mf / ml / S1 / V / x / l1 |_N_| [] => [] + empty_S
   (* go through every disjunct to union the result *)
   | UVN_Cons : forall mf ml S1 V x l1 x1 e s1 r1s r2 S2 r0' S0' r0's S0's,
-    mf; ml; s1; S1; V |-aa x@l1 => r0' / S0' ->
-    mf; ml; S1; V; x: l1 |_N_| r1s => r0's + S0's ->
+    mf / ml / s1 / S1 / V |-aa x@l1 => r0' / S0' ->
+    mf / ml / S1 / V / x / l1 |_N_| r1s => r0's + S0's ->
     r2 = r0' ++ r0's ->
-    S2 = S0' ++ S0's ->
+    S2 = S0' |_| S0's ->
     (* checking l1 is sufficient because we never relabel functions *)
-    mf; ml; S1; V; x: l1 |_N_| <fun x1 *-> e, l1, s1> :: r1s => r2 + S2
+    mf / ml / S1 / V / x / l1 |_N_| <fun x1 *-> e, l1, s1> :: r1s => r2 + S2
 
-  where "mf ; ml ; s ; S ; V '|-aa' e => rc / Sv" := (analyze mf ml s S V e rc Sv)
-    and "mf ; ml ; s ; S ; V '|_A_|' r1 => r2 + S2" := (union_appl mf ml s S V r1 r2 S2)
-    and "mf ; ml ; s ; V ; l' ; e2 '|_V_|' S => r2 + S2" := (union_stitch mf ml s V l' e2 S r2 S2)
-    and "mf ; ml ; S ; V ; x : l1 '|_N_|' r1 => r2 + S2" := (union_varnonlocal mf ml S V x l1 r1 r2 S2).
+  where "mf / ml / s / S / V '|-aa' e => rc / Sv" := (analyze mf ml s S V e rc Sv)
+    and "mf / ml / s / S / V '|_A_|' r1 => r2 + S2" := (union_appl mf ml s S V r1 r2 S2)
+    and "mf / ml / s / S / V / l' / e2 '|_V_|' S' => r2 + S2" := (union_stitch mf ml s S V l' e2 S' r2 S2)
+    and "mf / ml / S / V / x / l1 '|_N_|' r1 => r2 + S2" := (union_varnonlocal mf ml S V x l1 r1 r2 S2).
 
 Scheme analyze_mut := Induction for union_appl Sort Prop
 with union_appl_mut := Induction for analyze Sort Prop.
@@ -121,11 +125,10 @@ with union_appl_mut := Induction for analyze Sort Prop.
 (* Check analyze_ind. *)
 (* Check union_appl_mut. *)
 
-(* full automation *)
 Ltac solve_analyze :=
   repeat match goal with
-  | [|- _; _; _; _; _ |-aa (_ <-* _) @ _ => _ / _] => eapply A_Appl
-  | [|- _; _; _; _; _ |-aa ($fun _ *-> _) @ _ => _ / _] => eapply A_Val
+  | [|- _ / _ / _ / _ / _ |-aa (_ <-* _) @ _ => _ / _] => eapply A_Appl
+  | [|- _ / _ / _ / _ / _ |-aa ($fun _ *-> _) @ _ => _ / _] => eapply A_Val
   | [|- analyze ?mf ?ml _ _ _ (Lexpr (Ident ?x) ?l) _ _] =>
     (* e.g., evaluate X to "x" *)
     let x := eval cbv in x in
@@ -139,28 +142,48 @@ Ltac solve_analyze :=
       end
     | _ => idtac
     end
-  | [|- _; _; _; _; _ |-aa ?eg => _ / _] =>
+  | [|- _ / _ / _ / _ / _ |-aa ?eg => _ / _] =>
     unfold eg, to_lexpr; simpl
-  | [|- _; _; _; _; _ |_A_| ?r1 => _ + _] =>
+  | [|- _ / _ / _ / _ / _ |_A_| ?r1 => _ + _] =>
     match r1 with
     | _ :: _ => econstructor
     | _ ++ _ => simpl; econstructor
     | [] => constructor
     end
-  | [|- _; _; _; _; ?l'; _ |_V_| ?S => _ + _] =>
+  | [|- _ / _ / _ / _ / _ / ?l' / _ |_V_| ?S => _ + _] =>
     match S with
-    | (l' :: _) :: _ => eapply ST_Cons
-    | _ :: _ => eapply ST_Cons_Skip
-    | [] => constructor
+    | ?s ~> _ \ ?s => 
+      let Contra := fresh "Contra" in
+      let H := fresh "H" in
+      rewrite <- Sub_Add_new by (intro Contra; invert Contra; invert H);
+      solve_analyze
+    (* TODO: implement decision procedure for union_stitch *)
+    (* | ?s ~> _ =>
+      match s with
+      | l' :: _ => eapply ST_Cons
+      | _ :: _ => eapply ST_Cons_Skip
+      | [] => constructor
+      end *)
+    | empty_S => constructor
     end
-  | [|- _; _; _; _; _: _ |_N_| ?r1 => _ + _] =>
+  | [|- _ / _ / _ / _ / _ / _ |_N_| ?r1 => _ + _] =>
     match r1 with
     | _ :: _ => econstructor
     | _ ++ _ => simpl; econstructor
     | [] => constructor
     end
+  | [|- _ ? _ ~> empty_S] => apply Union_intror; constructor
+  | [|- context[_ |_| empty_S]] => simpl; rewrite Empty_set_zero_right
+  | [H: _ ? empty_S |- _] => contradiction
+  | [|- _ ? _ |_| empty_S ] =>
+    apply Ensembles.Union_introl
+  | [|- _ ? empty_S |_| _] =>
+    apply Ensembles.Union_intror
+  | [|- forall l'' s', _ = l'' :: s' -> l'' <> _] =>
+    let H := fresh "H" in
+    intros l'' s' H; invert H; intro; discriminate
+  | [|- _ = _] => simpl; reflexivity
   | [|- _ <> _] => discriminate
-  | [|- _ = _] => reflexivity
   end.
 
 (* simple function value *)
@@ -169,7 +192,8 @@ Definition eg_val_mf := build_myfun eg_val.
 Definition eg_val_ml := build_mylexpr eg_val.
 
 Example eg_val_correct :
-  eg_val_mf; eg_val_ml; []; []; [] |-aa eg_val => [<fun X *-> X@0, 1, []>] / [].
+  eg_val_mf / eg_val_ml / [] / empty_S / empty_V |-aa eg_val =>
+    [<fun X *-> X@0, 1, []>] / empty_S.
 Proof.
   apply A_Val.
 Qed.
@@ -179,30 +203,16 @@ Definition eg_loc := to_lexpr <{ ($fun X -> X) <- ($fun Y -> Y) }>.
 (* Compute eg_loc. *)
 Definition eg_loc_mf := build_myfun eg_loc.
 Definition eg_loc_ml := build_mylexpr eg_loc.
+Definition eg_loc_S : S_set := Ensembles.Singleton sigma [4].
 
 Example eg_loc_correct :
-  eg_loc_mf; eg_loc_ml; []; []; [] |-aa eg_loc => [<fun Y *-> Y@2, 3, []>] / [].
+  eg_loc_mf / eg_loc_ml / [] / empty_S / empty_V |-aa eg_loc =>
+    [<fun Y *-> Y@2, 3, []>] / eg_loc_S.
 Proof.
   solve_analyze.
-Qed.
-
-(* verbose version for stepping through proof *)
-Example eg_loc_correct' :
-  eg_loc_mf; eg_loc_ml; []; []; [] |-aa eg_loc => [<fun Y *-> Y@2, 3, []>] / [].
-Proof with try reflexivity.
-  eapply A_Appl...
-  - apply A_Val.
-  - eapply UA_Cons.
-    + eapply A_VarLocal...
-      eapply ST_Cons.
-      * reflexivity.
-      * apply A_Val.
-      * apply ST_Nil.
-      * reflexivity.
-      * reflexivity.
-    + apply UA_Nil.
-    + reflexivity.
-    + reflexivity.
+  eapply ST_Cons; solve_analyze.
+  - auto with sets.
+  - reflexivity.
 Qed.
 
 (* application involving non-local variable lookup *)
@@ -213,54 +223,101 @@ Definition eg_noloc :=
 (* Compute eg_noloc. *)
 Definition eg_noloc_mf := build_myfun eg_noloc.
 Definition eg_noloc_ml := build_mylexpr eg_noloc.
+Definition eg_noloc_S := [8] ~> [5] ~> empty_S.
 
 Example eg_noloc_correct :
-  eg_noloc_mf; eg_noloc_ml; []; []; [] |-aa eg_noloc => [<fun Z *-> Z@3, 4, []>] / [].
+  eg_noloc_mf / eg_noloc_ml / [] / empty_S / empty_V |-aa eg_noloc =>
+    [<fun Z *-> Z@3, 4, []>] / eg_noloc_S.
 Proof.
   solve_analyze.
+  eapply ST_Cons; solve_analyze.
+  - apply Union_intror. constructor.
+  - solve_analyze.
+    eapply ST_Cons_Skip; solve_analyze.
+  - solve_analyze.
+    (* deduplicate set *)
+    rewrite Non_disjoint_union by auto with sets.
+    eapply ST_Cons; solve_analyze.
+    + auto with sets.
+    + rewrite add_comm. solve_analyze.
+      eapply ST_Cons_Skip; solve_analyze.
+    + solve_analyze.
+  - reflexivity.
 Qed.
 
-(* verbose version for stepping through proof *)
+(* verbose version for stepping through *)
 Example eg_noloc_correct' :
-  eg_noloc_mf; eg_noloc_ml; []; []; [] |-aa eg_noloc => [<fun Z *-> Z@3, 4, []>] / [].
-Proof with try reflexivity.
-  eapply A_Appl...
-  - eapply A_Appl...
+  eg_noloc_mf / eg_noloc_ml / [] / empty_S / empty_V |-aa eg_noloc =>
+    [<fun Z *-> Z@3, 4, []>] / eg_noloc_S.
+Proof.
+  eapply A_Appl.
+  - eapply A_Appl.
     + apply A_Val.
-    + eapply UA_Cons.
+    + reflexivity.
+    + reflexivity.
+    + eapply UA_Cons; try rewrite Empty_set_zero_right.
       * apply A_Val.
       * apply UA_Nil.
       * reflexivity.
       * reflexivity.
+  - reflexivity.
+  - reflexivity.
   - eapply UA_Cons.
-    + eapply A_VarNonLocal...
+    + eapply A_VarNonLocal.
+      * reflexivity.
+      * reflexivity.
       * discriminate.
+      * reflexivity.
       * eapply ST_Cons.
+        -- apply Union_intror. constructor.
         -- reflexivity.
-        -- eapply A_Appl...
+        -- eapply A_Appl.
            ++ apply A_Val.
+           ++ reflexivity.
+           ++ reflexivity.
            ++ eapply UA_Cons.
               ** apply A_Val.
               ** apply UA_Nil.
               ** reflexivity.
               ** reflexivity.
-        -- apply ST_Nil.
+        -- rewrite <- Sub_Add_new by (intro Contra; invert Contra; invert H).
+           eapply ST_Cons_Skip.
+           ++ apply Union_intror. constructor.
+           ++ intros. invert H. intro. discriminate.
+           ++ rewrite <- Sub_Add_new.
+              ** apply ST_Nil.
+              ** intro Contra. contradiction.
         -- reflexivity.
-        -- reflexivity.
+        -- simpl. repeat rewrite Empty_set_zero_right.
+           rewrite Non_disjoint_union.
+           ++ reflexivity.
+           ++ apply Union_introl. apply Union_intror. constructor.
       * eapply UVN_Cons.
-        -- eapply A_VarLocal...
-           eapply ST_Cons.
-           ++ reflexivity.
-           ++ apply A_Val.
-           ++ apply ST_Nil.
+        -- eapply A_VarLocal.
            ++ reflexivity.
            ++ reflexivity.
-        -- eapply UVN_Nil.
-        -- reflexivity.
-        -- reflexivity.
+           ++ reflexivity.
+           ++ reflexivity.
+           ++ eapply ST_Cons.
+              ** apply Union_introl. apply Union_intror. constructor.
+              ** reflexivity.
+              ** apply A_Val.
+              ** rewrite add_comm. rewrite <- Sub_Add_new.
+                 eapply ST_Cons_Skip.
+                 --- apply Union_intror. constructor.
+                 --- intros. invert H. intro. discriminate.
+                 --- rewrite <- Sub_Add_new.
+                     +++ apply ST_Nil.
+                     +++ intro Contra. contradiction.
+                 --- intro Contra. invert Contra; invert H.
+              ** simpl. reflexivity.
+              ** rewrite Empty_set_zero_right. reflexivity.
+        -- apply UVN_Nil.
+        -- simpl. reflexivity.
+        -- rewrite Empty_set_zero_right. reflexivity.
     + apply UA_Nil.
     + reflexivity.
-    + reflexivity.
+    + rewrite Empty_set_zero_right. reflexivity.
 Qed.
 
 (* TODO: add examples to demonstrate ST_Cons_Skip *)

--- a/formal/Abstract/Common.v
+++ b/formal/Abstract/Common.v
@@ -1,7 +1,9 @@
-From Coq Require Import Arith.Arith.
-From DDE.Common Require Export Lang.
+From Coq Require Import Arith.Arith Sets.Ensembles.
+From DDE.Common Require Export Lang Sets.
 
-Definition s_set : Type := list sigma.
+(* set of call stacks *)
+Definition S_set : Type := set sigma.
+Definition empty_S : S_set := @empty_set sigma.
 
 Fixpoint prune_sigma (s : sigma) (k : nat) (acc : sigma) : sigma := 
   match s with

--- a/formal/Abstract/Pure.v
+++ b/formal/Abstract/Pure.v
@@ -8,20 +8,20 @@ Reserved Notation
           ml at next level, s at next level, S at next level, Sv at next level).
 
 Inductive analyze
-  : myfun -> mylexpr -> sigma -> s_set -> lexpr -> res -> s_set -> Prop
+  : myfun -> mylexpr -> sigma -> S_set -> lexpr -> res -> S_set -> Prop
 :=
   | A_Val : forall mf ml s S v l,
     mf / ml / s / S |-a ($v)@l => (<v, l, s>) / S
   | A_Appl : forall mf ml s S e1 e2 l rv Sv x e l1 s1 S1,
     mf / ml / s / S |-a e1 => <fun x *-> e, l1, s1> / S1 ->
-    mf / ml / prune_sigma2 (l :: s) / ((l :: s) :: S1) |-a e => rv / Sv ->
+    mf / ml / prune_sigma2 (l :: s) / ((l :: s) ~> S1) |-a e => rv / Sv ->
     mf / ml / s / S |-a (e1 <-* e2) @ l => rv / Sv
   (* TODO: should s' be universally/existentially quantified? *)
   | A_VarLocal : forall mf ml e1 e2 l' s S x l rv Sv mf_l e s',
     mf l = Some mf_l ->
     ml mf_l = Some <{ ($fun x *-> e) @ mf_l }> ->
     ml l' = Some <{ (e1 <-* e2) @ l' }> ->
-    (exists s0, In s0 S /\ s0 = l' :: s ++ s') ->
+    (exists s0, s0 ? S /\ s0 = l' :: s ++ s') ->
     mf / ml / (s ++ s') / S |-a e2 => rv / Sv ->
     mf / ml / (l' :: s) / S |-a x@l => rv / Sv
   | A_VarNonLocal : forall mf ml e1 e2 l2 s S x l rv Sv x1 e l1 s1 S1,

--- a/formal/Common/Sets.v
+++ b/formal/Common/Sets.v
@@ -1,0 +1,45 @@
+From Coq Require Export Sets.Ensembles Sets.Powerset_Classical_facts Sets.Powerset_facts.
+From DDE.Common Require Import Tactics.
+
+Definition set (A : Type) : Type := Ensemble A.
+
+Definition empty_set {A : Type} : set A := Empty_set A.
+
+Definition add {A : Type} (S : set A) (x : A) : set A :=
+  Add A S x.
+
+Definition subtract {A : Type} (S : set A) (x : A) : set A :=
+  Subtract A S x.
+
+Definition union {A : Type} (S1 : set A) (S2 : set A) : set A :=
+  Union A S1 S2.
+
+Notation "x ~> S" := (add S x)
+  (at level 67, right associativity).
+Notation "S \ x" := (subtract S x)
+  (at level 68, left associativity).
+Notation "S1 |_| S2" := (union S1 S2)
+  (at level 69, S2 at next level, no associativity).
+Notation "x ? S" := (In _ S x)
+  (at level 70, S at next level, no associativity).
+
+Example eg_add := 1 ~> 2 ~> 3 ~> empty_set.
+Example eg_sub := (1 ~> 2 ~> empty_set \ 1 \ 2) ~> empty_set.
+Example eg_union := 1 ~> empty_set |_| empty_set.
+Example eg_in := 1 ? 1 ~> empty_set \ 1.
+
+Example eg_not_in : ~ eg_in.
+Proof.
+  unfold eg_in, "?", "~>", "\".
+  intro Contra. inversion Contra.
+  apply H0. inversion H.
+  - contradiction.
+  - assumption.
+Qed.
+
+(* overload standard library lemma to not disrupt notations *)
+Lemma add_comm : forall {A : Type} (S : set A) (x y : A),
+  x ~> y ~> S = y ~> x ~> S.
+Proof.
+  intros. apply Add_commutative.
+Qed.

--- a/formal/Common/dune
+++ b/formal/Common/dune
@@ -1,3 +1,3 @@
 (coq.theory
  (name DDE.Common)
- (modules Maps Lang Tactics))
+ (modules Maps Sets Lang Tactics))

--- a/program_analysis/src/lib.ml
+++ b/program_analysis/src/lib.ml
@@ -331,7 +331,8 @@ let analyze ~debug e =
      Format.printf "\n%s\n\n" @@ show_expr e;
      Format.printf "****** Label Table ******\n";
      print_myexpr myexpr;
-     Format.printf "****** Label Table ******\n\n"))
+     Format.printf "****** Label Table ******\n\n";
+     Hashset.iter (fun s -> Format.printf "%s\n" (show_sigma_t s)) s_set))
   [@coverage off];
 
   clean_up ();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #62
* __->__ #66
* #65

In order to close in the gap between this formalization and the actual
system, this commit makes significant changes to the core logic:

- Use Coq's Ensemble instead of list for sets. Introduce notations for
key operations to gain concision.
- Correct a few holes in the logic to properly thread the S set.
- For now, `solve_analyze` doesn't fully automate proofs and instead
delegates non-trivial cases (e.g., stack stitching) to the user. Full
automation may come soon.
- Revert to the `_ / _ / _ / _ / _ '|-aa' _ => _ / _` syntax from `;`
to avoid clashing with list notations.

Test plan:

`dune build formal` and see that everything compiles.