### PR TITLE
[Formal] Fix stack pruning algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ _build
 _coverage
 *.coverage
 .DS_Store
+
+.lia.cache

--- a/formal/Abstract/AllPaths.v
+++ b/formal/Abstract/AllPaths.v
@@ -26,10 +26,10 @@ Reserved Notation
 
 (* stack stitching union operation *)
 Reserved Notation
-         "mf / ml / s / S / V / l' / e2 '|_S_|' S' => r2 + S2"
+         "mf / ml / S / V / l' / s / e2 '|_S_|' S' => r2 + S2"
          (at level 40, S' at level 99, e2 custom lang at level 99,
-          ml at next level, s at next level, S at next level, V at next level,
-          l' at next level, r2 at next level).
+          ml at next level, S at next level, V at next level,
+          l' at next level, s at next level, r2 at next level).
 
 (* union operation seen in Var Non-Local *)
 Reserved Notation
@@ -46,23 +46,23 @@ Inductive analyze
     mf / ml / s / S / V |-aa ($v)@l => [<v, l, s>] / S
   | A_Appl : forall mf ml s S V e e' l r2 S2 r1 S1 ls ls_pruned,
     mf / ml / s / S / V |-aa e => r1 / S1 ->
-    ls = (l :: s) ->
+    ls = l :: s ->
     ls_pruned = prune_sigma2 ls ->
     mf / ml / ls_pruned / (ls ~> S1) / ((e, ls_pruned) :: V) |_A_| r1 => r2 + S2 ->
     mf / ml / s / S / V |-aa (e <-* e') @ l => r2 / S2
   | A_VarLocal : forall mf ml s0 S V x l r1 S1 l' s mf_l e e1 e2,
-    s0 = (l' :: s) ->
+    s0 = l' :: s ->
     mf l = Some mf_l ->
     ml mf_l = Some <{ ($fun x *-> e) @ mf_l }> ->
     ml l' = Some <{ (e1 <-* e2) @ l' }> ->
-    mf / ml / s / S / ((e, s0) :: V) / l' / e2 |_S_| S => r1 + S1 ->
+    mf / ml / S / ((e, s0) :: V) / l' / s / e2 |_S_| S => r1 + S1 ->
     mf / ml / s0 / S / V |-aa x@l => r1 / S1
   | A_VarNonLocal : forall mf ml l2 s S V x l r2 S2 mf_l x1 e e1 e2 r1 S1,
     mf l = Some mf_l ->
     ml mf_l = Some <{ ($fun x1 *-> e) @ mf_l }> ->
     x <> x1 ->
     ml l2 = Some <{ (e1 <-* e2) @ l2 }> ->
-    mf / ml / s / S / V / l2 / e1 |_S_| S => r1 + S1 ->
+    mf / ml / S / V / l2 / s / e1 |_S_| S => r1 + S1 ->
     mf / ml / S1 / V / x / mf_l |_N_| r1 => r2 + S2 ->
     mf / ml / (l2 :: s) / S / V |-aa x@l => r2 / S2
 (* TODO: add Stub rules *)
@@ -83,22 +83,22 @@ with union_stitch
   : myfun -> mylexpr -> sigma -> S_set -> V_set -> nat -> lexpr -> S_set -> disj -> S_set -> Prop
 :=
   | ST_Nil : forall mf ml s S V e2 l',
-    mf / ml / s / S / V / l' / e2 |_S_| [] => [] + []
+    mf / ml / S / V / l' / s / e2 |_S_| [] => [] + []
   (* skip current stack s'' if its top frame isn't l' *)
   | ST_Cons_Skip : forall mf ml s S V l' e2 s'' S' r0s S0s,
     (forall l'' s', s'' = l'' :: s' -> l'' <> l') ->
     (* go through the rest of the stacks *)
-    mf / ml / s / S / V / l' / e2 |_S_| S' => r0s + S0s ->
-    mf / ml / s / S / V / l' / e2 |_S_| s'' :: S' => r0s + S0s
+    mf / ml / S / V / l' / s / e2 |_S_| S' => r0s + S0s ->
+    mf / ml / S / V / l' / s / e2 |_S_| s'' :: S' => r0s + S0s
   (* matching stack to execute and union with *)
   | ST_Cons : forall mf ml s S V l' e2 s'' S' r1 S1 s' r0 S0 r0s S0s,
     (* a match! *)
     s'' = l' :: s ++ s' ->
     mf / ml / (s ++ s') / S / V |-aa e2 => r0 / S0 ->
-    mf / ml / s / S / V / l' / e2 |_S_| S' => r0s + S0s ->
+    mf / ml / S / V / l' / s / e2 |_S_| S' => r0s + S0s ->
     r1 = r0 ++ r0s ->
     S1 = S0 |_| S0s ->
-    mf / ml / s / S / V / l' / e2 |_S_| s'' :: S' => r1 + S1
+    mf / ml / S / V / l' / s / e2 |_S_| s'' :: S' => r1 + S1
 
 with union_varnonlocal
   : myfun -> mylexpr -> S_set -> V_set -> expr -> nat -> disj -> disj -> S_set -> Prop
@@ -113,21 +113,38 @@ with union_varnonlocal
     (* checking l1 is sufficient because we never relabel functions *)
     mf / ml / S1 / V / x / l1 |_N_| <fun x1 *-> e, l1, s1> :: r1s => r2 + S2
 
-  where "mf / ml / s / S / V '|-aa' e => rc / Sv" := (analyze mf ml s S V e rc Sv)
-    and "mf / ml / s / S / V '|_A_|' r1 => r2 + S2" := (union_appl mf ml s S V r1 r2 S2)
-    and "mf / ml / s / S / V / l' / e2 '|_S_|' S' => r2 + S2" := (union_stitch mf ml s S V l' e2 S' r2 S2)
-    and "mf / ml / S / V / x / l1 '|_N_|' r1 => r2 + S2" := (union_varnonlocal mf ml S V x l1 r1 r2 S2).
+  where "mf / ml / s / S / V '|-aa' e => rc / Sv" :=
+      (analyze mf ml s S V e rc Sv)
+    and "mf / ml / s / S / V '|_A_|' r1 => r2 + S2" :=
+      (union_appl mf ml s S V r1 r2 S2)
+    and "mf / ml / S / V / l' / s / e2 '|_S_|' S' => r2 + S2" :=
+      (union_stitch mf ml s S V l' e2 S' r2 S2)
+    and "mf / ml / S / V / x / l1 '|_N_|' r1 => r2 + S2" :=
+      (union_varnonlocal mf ml S V x l1 r1 r2 S2).
 
-Scheme analyze_mut := Induction for union_appl Sort Prop
-with union_appl_mut := Induction for analyze Sort Prop.
+Scheme analyze_union_appl := Induction for union_appl Sort Prop
+  with union_appl_analyze := Induction for analyze Sort Prop.
+
+Scheme analyze_union_stitch := Induction for union_stitch Sort Prop
+  with union_stitch_analyze := Induction for analyze Sort Prop.
+
+Scheme analyze_union_varnonlocal := Induction for union_varnonlocal Sort Prop
+with union_varnonlocal_analyze := Induction for analyze Sort Prop.
 
 (* Check analyze_ind. *)
-(* Check union_appl_mut. *)
+(* Check union_appl_analyze. *)
+
+Fixpoint starts_with {A : Type} {eqb_A : Eqb A} (ls1 ls2 : list A) : bool :=
+  match ls1, ls2 with
+  | _, [] => true
+  | [], _ => false
+  | h1 :: t1, h2 :: t2 => (eqb h1 h2 && starts_with t1 t2)%bool
+  end.
 
 (* full automation *)
 Ltac solve_analyze :=
   repeat match goal with
-  | [|- context[_ ~> []]] => unfold "~>"; simpl
+  | [|- context[_ ~> _]] => unfold prune_sigma2, "~>"; simpl
 
   | [|- _ / _ / _ / _ / _ |-aa (_ <-* _) @ _ => _ / _] => econstructor
   | [|- _ / _ / _ / _ / _ |-aa ($fun _ *-> _) @ _ => _ / _] => constructor
@@ -151,13 +168,19 @@ Ltac solve_analyze :=
     | _ :: _ => econstructor
     | [] => constructor
     end
-  | [|- _ / _ / _ / _ / _ / ?l' / _ |_S_| ?S => _ + _] =>
+  | [|- _ / _ / _ / _ / ?l' / ?s / _ |_S_| ?S => _ + _] =>
     match S with
-    | ?s :: _ =>
-      match s with
-      | l' :: _ => eapply ST_Cons
+    | ?s'' :: _ =>
+      match s'' with
+      | l' :: ?s' =>
+        tryif
+          match eval cbv in (starts_with s' s)
+            with true => idtac | false => fail
+          end
+        then eapply ST_Cons
+        else eapply ST_Cons_Skip
       | _ :: _ => apply ST_Cons_Skip
-      | [] => constructor
+      | [] => idtac "unreachable"
       end
     | [] => constructor
     end
@@ -173,6 +196,9 @@ Ltac solve_analyze :=
   | [|- _ = _] => simpl; reflexivity
   | [|- _ <> _] => discriminate
   end.
+
+(* Example yoyo : [1] = 1 :: [] ++ [].
+Proof. *)
 
 (* simple function value *)
 Definition eg_val := to_lexpr <{ $fun X -> X }>.
@@ -190,35 +216,33 @@ Definition eg_loc := to_lexpr <{ ($fun X -> X) <- ($fun Y -> Y) }>.
 (* Compute eg_loc. *)
 Definition eg_loc_mf := build_myfun eg_loc.
 Definition eg_loc_ml := build_mylexpr eg_loc.
-Definition eg_loc_S : S_set := [4] ~> [].
 
 Example eg_loc_correct :
-  eg_loc_mf / eg_loc_ml / [] / [] / [] |-aa eg_loc => [<fun Y *-> Y@2, 3, []>] / eg_loc_S.
+  eg_loc_mf / eg_loc_ml / [] / [] / [] |-aa eg_loc => [<fun Y *-> Y@2, 3, []>] / [[4]].
 Proof.
   solve_analyze.
 Qed.
 
 (* application involving non-local variable lookup *)
-Definition eg_noloc :=
+Definition eg_noloc1 :=
   to_lexpr <{ (($fun X -> $fun Y -> X)
                 <- $fun Z -> Z)
                 <- $fun N -> N }>.
-(* Compute eg_noloc. *)
-Definition eg_noloc_mf := build_myfun eg_noloc.
-Definition eg_noloc_ml := build_mylexpr eg_noloc.
-Definition eg_noloc_S := [8] ~> [5] ~> [].
+(* Compute eg_noloc1. *)
+Definition eg_noloc1_mf := build_myfun eg_noloc1.
+Definition eg_noloc1_ml := build_mylexpr eg_noloc1.
 
-Example eg_noloc_correct :
-  eg_noloc_mf / eg_noloc_ml / [] / [] / [] |-aa eg_noloc =>
-    [<fun Z *-> Z@3, 4, []>] / eg_noloc_S.
+Example eg_noloc1_correct :
+  eg_noloc1_mf / eg_noloc1_ml / [] / [] / [] |-aa eg_noloc1 =>
+    [<fun Z *-> Z@3, 4, []>] / [[8]; [5]].
 Proof.
   solve_analyze.
 Qed.
 
 (* verbose version for stepping through *)
-Example eg_noloc_correct' :
-  eg_noloc_mf / eg_noloc_ml / [] / [] / [] |-aa eg_noloc =>
-    [<fun Z *-> Z@3, 4, []>] / eg_noloc_S.
+Example eg_noloc1_correct' :
+  eg_noloc1_mf / eg_noloc1_ml / [] / [] / [] |-aa eg_noloc1 =>
+    [<fun Z *-> Z@3, 4, []>] / [[8]; [5]].
 Proof.
   eapply A_Appl.
   - eapply A_Appl.
@@ -276,4 +300,27 @@ Proof.
     + reflexivity.
 Qed.
 
-(* TODO: add examples to demonstrate ST_Cons_Skip *)
+Definition eg_noloc2 :=
+  to_lexpr <{ ($fun X -> (($fun Y -> Y) <- X)) <- $fun Z -> Z }>.
+(* Compute eg_noloc2. *)
+Definition eg_noloc2_mf := build_myfun eg_noloc2.
+Definition eg_noloc2_ml := build_mylexpr eg_noloc2.
+
+Example eg_noloc2_correct :
+  eg_noloc2_mf / eg_noloc2_ml / [] / [] / [] |-aa eg_noloc2 =>
+    [<fun Z *-> Z@5, 6, []>] / [[3; 7]; [7]].
+Proof.
+  solve_analyze.
+Qed.
+
+Theorem deterministic : forall mf ml s S V e r1 S1 r2 S2,
+  mf / ml / s / S / V |-aa e => r1 / S1 ->
+  mf / ml / s / S / V |-aa e => r2 / S2 ->
+  r1 = r2.
+Proof.
+  intros. generalize dependent r2.
+  (* issues:
+    1. generated ind principles don't work with notation
+    2. need to apply all three principles "at once" *)
+  (* eapply (analyze_ind H). *)
+Abort.

--- a/formal/Abstract/Common.v
+++ b/formal/Abstract/Common.v
@@ -1,4 +1,4 @@
-From Coq Require Import Arith.Arith.
+From Coq Require Import Arith.Arith Lia.
 From DDE.Common Require Export Lang.
 
 (* a set of call stacks *)
@@ -45,4 +45,17 @@ Fixpoint prune_sigma (s : sigma) (k : nat) (acc : sigma) : sigma :=
     else prune_sigma ls (k - 1) (l :: acc)
   end.
 
-Definition prune_sigma2 (s : sigma) : sigma := prune_sigma s 2 [].
+Definition prune_sigma2 (s : sigma) : sigma := rev (prune_sigma s 2 []).
+
+Lemma prune_sigma2_cap : forall s, List.length (prune_sigma2 s) <= 2.
+Proof.
+  do 3 (destruct s; auto).
+Qed.
+
+Lemma prune_sigma2_order : forall s,
+  List.length s <= 2 ->
+  prune_sigma2 s = s.
+Proof.
+  do 3 (destruct s; auto).
+  simpl. lia.
+Qed.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #70
* __->__ #71

This commit fixes `prune_sigma2` so that it preserves the order of the
elements in it (if there are less than or equal to two). Specify and
prove relevant lemmas about it. Adjust `solve_analyze` to properly match
each stack in S before deciding whether to stitch with it.

Test plan:

CI passes. `dune build formal` and see that everything compiles.