### PR TITLE
[PA] Path conditions

### DIFF
--- a/program_analysis/src/debugutils.ml
+++ b/program_analysis/src/debugutils.ml
@@ -5,6 +5,12 @@ open Grammar
 
 let ff = Format.fprintf
 
+(* let rec pp_path_cond fmt = function
+   | [] -> ()
+   | [ (e, b) ] -> ff fmt "%a = %b" Interpreter.Pp.pp_expr e b
+   | (e, b) :: cond ->
+       ff fmt "%a = %b /\\ %a" Interpreter.Pp.pp_expr e b pp_path_cond cond *)
+
 let rec pp_atom fmt (v : atom) =
   match v with
   | IntAtom x -> ff fmt "%d" x
@@ -15,12 +21,7 @@ let rec pp_atom fmt (v : atom) =
           ff fmt "@[<hv>function %s ->@;<1 4>%a@]" i Interpreter.Pp.pp_expr le
       | _ -> raise Unreachable)
   | ResAtom choices | LabelResAtom (choices, _) | ExprResAtom (choices, _) ->
-      if List.length choices = 1 then ff fmt "%a" pp_atom (List.hd choices)
-      else
-        ff fmt "(%s)"
-          (choices
-          |> List.map (fun res -> Format.asprintf "%a" pp_atom res)
-          |> String.concat " | ")
+      ff fmt "%a" pp_res choices
   | OpAtom op -> (
       match op with
       | PlusOp (r1, r2) -> ff fmt "(%a + %a)" pp_res r1 pp_res r2
@@ -30,8 +31,9 @@ let rec pp_atom fmt (v : atom) =
       | OrOp (r1, r2) -> ff fmt "(%a or %a)" pp_res r1 pp_res r2
       | NotOp r1 -> ff fmt "(not %a)" pp_res r1)
   | LabelStubAtom _ | ExprStubAtom _ -> ff fmt "stub"
+  | PathCondAtom ((e, b), a) ->
+      ff fmt "(%a = %b ⊩ %a)" Interpreter.Pp.pp_expr e b pp_atom a
 
-(* write a list pretty printer using %a *)
 and pp_res fmt = function
   | [] -> ()
   | [ a ] -> ff fmt "%a" pp_atom a

--- a/program_analysis/src/grammar.ml
+++ b/program_analysis/src/grammar.ml
@@ -3,11 +3,8 @@ open Interpreter.Ast
 
 module State = struct
   module T = struct
-    type lstate = int * sigma
-    [@@deriving compare, sexp, show { with_path = false }]
-
-    type estate = expr * sigma
-    [@@deriving compare, sexp, show { with_path = false }]
+    type lstate = int * sigma [@@deriving compare, sexp]
+    type estate = expr * sigma [@@deriving compare, sexp]
 
     type state = Lstate of lstate | Estate of estate
     [@@deriving compare, sexp]
@@ -19,6 +16,8 @@ module State = struct
   include Comparable.Make (T)
 end
 
+type path_cond = expr * bool [@@deriving compare, sexp]
+
 type op =
   | PlusOp of res * res
   | MinusOp of res * res
@@ -28,22 +27,32 @@ type op =
   | NotOp of res
 
 and atom =
+  | IntAtom of int
+  | BoolAtom of bool
+  | FunAtom of expr * int * sigma
   | OpAtom of op
   | ResAtom of res
   | LabelResAtom of res * State.lstate
   | ExprResAtom of res * State.estate
-  | FunAtom of expr * int * sigma
   | LabelStubAtom of State.lstate
   | ExprStubAtom of State.estate
-  | IntAtom of int
-  | BoolAtom of bool
+  | PathCondAtom of path_cond * atom
 
-and res = atom list [@@deriving show { with_path = false }, compare, sexp]
+and res = atom list [@@deriving compare, sexp]
 
 (* used to accumulate disjuncts when stitching stacks at Var Non-Local *)
 module Choice = struct
   module T = struct
     type t = atom [@@deriving compare, sexp]
+  end
+
+  include T
+  include Comparable.Make (T)
+end
+
+module PathChoice = struct
+  module T = struct
+    type t = path_cond * atom [@@deriving compare, sexp]
   end
 
   include T

--- a/program_analysis/tests/tests.ml
+++ b/program_analysis/tests/tests.ml
@@ -28,9 +28,9 @@ let test_local_stitching _ =
         add2 0;;")
 
 let test_if _ =
-  assert_equal "(1 + (10 - 1))"
+  assert_equal "((n = 0) = false ⊩ (1 + (10 - 1)))"
     (pau "(fun id -> id 10) (fun n -> if n = 0 then 0 else 1 + (n - 1));;");
-  assert_equal "1" (pau "if true then 1 else 2;;");
+  assert_equal "(true = true ⊩ 1)" (pau "if true then 1 else 2;;");
   assert_equal "1"
     (pau "(fun x -> (if true then (fun y -> y) else (fun z -> z)) x) 1;;")
 
@@ -58,7 +58,9 @@ let test_currying _ =
         add1 1 + add2 1 + add3 1 + add4 1 + add5 1;;")
 
 let test_recursion _ =
-  assert_equal "(1 + (1 + (1 + ((1 + stub) | 0))))"
+  assert_equal
+    "((n = 0) = false ⊩ (1 + ((n = 0) = false ⊩ (1 + ((n = 0) = false ⊩ (1 + \
+     (((n = 0) = false ⊩ (1 + stub)) | ((n = 0) = true ⊩ 0))))))))"
     (pau
        "let id = fun self -> fun n -> if n = 0 then 0 else 1 + self self (n - \
         1) in id id 10;;")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #75
* __->__ #73

This commit adds path conditions to results from conditionals and
accumulate them up the proof tree so that Eval can use them to gain more
precision, which may be implemented soon. Path conditions are denoted
by ⊩ (LHS).

Test plan:

`dune test program_analysis` and see that all tests pass.