### PR TITLE
[PA] Minor adjustment to Eval

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ on:
       - "**"
     paths-ignore:
       - "**/*.md"
+      - "interpreter"
+      - "program_analysis"
 concurrency:
   group: ${{ github.head_ref || github.ref }}
   cancel-in-progress: true

--- a/program_analysis/src/grammar.ml
+++ b/program_analysis/src/grammar.ml
@@ -59,18 +59,9 @@ module PathChoice = struct
   include Comparable.Make (T)
 end
 
-module Maybe_int = struct
+module Maybe_prim = struct
   module T = struct
-    type t = DefInt of int | AnyInt [@@deriving compare, sexp]
-  end
-
-  include T
-  include Comparable.Make (T)
-end
-
-module Maybe_bool = struct
-  module T = struct
-    type t = DefBool of bool | AnyBool [@@deriving compare, sexp]
+    type t = DefInt of int | DefBool of bool | Any [@@deriving compare, sexp]
   end
 
   include T


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #74
* #73

Since our language is untyped [1], it doesn't really make sense to have
`Any**Int**`/`Any**Bool**`. Instead, just `Any` would do.

[1] Although we do raise exceptions at runtime on type mismatches.

Test plan:

`dune test program_analysis` and see that all tests pass.