### PR TITLE
[PA] Use results in path conditions instead of expressions

### DIFF
--- a/program_analysis/src/debugutils.ml
+++ b/program_analysis/src/debugutils.ml
@@ -31,8 +31,7 @@ let rec pp_atom fmt (v : atom) =
       | OrOp (r1, r2) -> ff fmt "(%a or %a)" pp_res r1 pp_res r2
       | NotOp r1 -> ff fmt "(not %a)" pp_res r1)
   | LabelStubAtom _ | ExprStubAtom _ -> ff fmt "stub"
-  | PathCondAtom ((e, b), a) ->
-      ff fmt "(%a = %b ⊩ %a)" Interpreter.Pp.pp_expr e b pp_atom a
+  | PathCondAtom ((r, b), a) -> ff fmt "(%a = %b ⊩ %a)" pp_res r b pp_atom a
 
 and pp_res fmt = function
   | [] -> ()

--- a/program_analysis/src/grammar.ml
+++ b/program_analysis/src/grammar.ml
@@ -16,8 +16,6 @@ module State = struct
   include Comparable.Make (T)
 end
 
-type path_cond = expr * bool [@@deriving compare, sexp]
-
 type op =
   | PlusOp of res * res
   | MinusOp of res * res
@@ -38,7 +36,8 @@ and atom =
   | ExprStubAtom of State.estate
   | PathCondAtom of path_cond * atom
 
-and res = atom list [@@deriving compare, sexp]
+and res = atom list
+and path_cond = res * bool [@@deriving compare, sexp]
 
 (* used to accumulate disjuncts when stitching stacks at Var Non-Local *)
 module Choice = struct

--- a/program_analysis/src/lib.ml
+++ b/program_analysis/src/lib.ml
@@ -221,7 +221,7 @@ let rec analyze_aux expr s pi v_set =
       let%map r_cond = analyze_aux e s pi v_set in
       r_cond |> eval_bool |> process_maybe_bools
       |> List.map ~f:(fun b ->
-             let path_cond = (e, b) in
+             let path_cond = (r_cond, b) in
              ( path_cond,
                analyze_aux
                  (if b then e_true else e_false)

--- a/program_analysis/tests/tests.ml
+++ b/program_analysis/tests/tests.ml
@@ -50,7 +50,7 @@ let test_local_stitching _ = gen_test local_stitching
 let conidtional =
   [
     (fun _ ->
-      ( "((n = 0) = false ⊩ (1 + (10 - 1)))",
+      ( "((10 = 0) = false ⊩ (1 + (10 - 1)))",
         pau "(fun id -> id 10) (fun n -> if n = 0 then 0 else 1 + (n - 1));;" ));
     (fun _ -> ("(true = true ⊩ 1)", pau "if true then 1 else 2;;"));
     (fun _ ->
@@ -98,8 +98,11 @@ let test_currying _ = gen_test currying
 let recursion =
   [
     (fun _ ->
-      ( "((n = 0) = false ⊩ (1 + ((n = 0) = false ⊩ (1 + ((n = 0) = false ⊩ (1 \
-         + (((n = 0) = false ⊩ (1 + stub)) | ((n = 0) = true ⊩ 0))))))))",
+      (* TODO: make more readable *)
+      ( "((10 = 0) = false ⊩ (1 + (((10 - 1) = 0) = false ⊩ (1 + ((((10 - 1) - \
+         1) = 0) = false ⊩ (1 + ((((((10 - 1) - 1) | ((((10 - 1) - 1) | (stub \
+         - 1)) - 1)) = 0) = false ⊩ (1 + stub)) | (((((10 - 1) - 1) | ((((10 - \
+         1) - 1) | (stub - 1)) - 1)) = 0) = true ⊩ 0))))))))",
         pau
           "let id = fun self -> fun n -> if n = 0 then 0 else 1 + self self (n \
            - 1) in id id 10;;" ));


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

This commit amends 4a656d4. Without additional info, it isn't very
helpful to show only the expression that's true/false. So, we instead
show its evaluated result. Perhaps in the future it's a better idea to
show the expression *and* annotate it with its position in the source
program.

Test plan:

`dune test program_analysis`.