### PR TITLE
[PA] Working CHC generator and verification test framework

### DIFF
--- a/program_analysis/src/debugutils.ml
+++ b/program_analysis/src/debugutils.ml
@@ -14,14 +14,10 @@ let parse s =
   Interpreter.Ast.reset_label ();
   expr
 
-let unparse v = Format.asprintf "%a" pp_res v
+let unparse = Format.asprintf "%a" pp_res
 let parse_analyze s = s |> parse |> analyze ~debug:!is_debug_mode
-
-let parse_analyze_unparse s =
-  s |> parse |> analyze ~debug:!is_debug_mode |> fun (r, _) -> unparse r
-
+let parse_analyze_unparse s = s |> parse_analyze |> unparse
 let pau = parse_analyze_unparse
 
-let parse_eval_print s =
-  s |> parse |> analyze ~debug:!is_debug_mode |> fun (r, _) ->
-  Format.printf "==> %a\n" pp_res
+let parse_analyze_print s =
+  s |> parse_analyze |> Format.printf "==> %a\n" pp_res

--- a/program_analysis/src/lib.ml
+++ b/program_analysis/src/lib.ml
@@ -362,17 +362,6 @@ let analyze ~debug e =
   let e = transform_let e in
   build_myfun e None;
   let r = analyze_aux e [] None (Set.empty (module State)) in
-  let r = Option.value_exn r in
-
-  (* Format.printf "\nresult:\n%a\n" Grammar.pp_res r; *)
-  (* Format.printf "result:\n%a\n" Utils.pp_res r; *)
-  (* Format.printf "\n"; *)
-  Solver.chcs_of_res r;
-  let chcs = Hash_set.to_list Solver.chcs in
-
-  (* Format.printf "CHCs:\n";
-     List.iter ~f:(fun chc -> Format.printf "%s\n" (Z3.Expr.to_string chc)) chcs; *)
-  Solver.reset ();
 
   (if !is_debug_mode then (
      Format.printf "\n%s\n\n" @@ show_expr e;
@@ -385,4 +374,4 @@ let analyze ~debug e =
   clean_up ();
   Hashset.clear s_set;
 
-  (r, chcs)
+  Option.value_exn r

--- a/program_analysis/src/main.ml
+++ b/program_analysis/src/main.ml
@@ -19,7 +19,7 @@ let toplevel_loop =
   in
   let safe_analyze_and_print ast =
     try
-      let r, _ = Lib.analyze ast ~debug:false in
+      let r = Lib.analyze ast ~debug:false in
       Format.printf "==> %a\n" Utils.pp_res r
     with ex -> print_exception ex
   in

--- a/program_analysis/src/utils.ml
+++ b/program_analysis/src/utils.ml
@@ -49,7 +49,7 @@ let rec pp_atom fmt = function
       | OrOp (r1, r2) -> ff fmt "(%a or %a)" pp_res r1 pp_res r2
       | NotOp r1 -> ff fmt "(not %a)" pp_res r1)
   | LabelStubAtom _ | ExprStubAtom _ -> ff fmt "stub"
-  | PathCondAtom ((r, b), a) -> ff fmt "(%a = %b ⊩ %a)" pp_res r b pp_res a
+  | PathCondAtom ((r, b), r') -> ff fmt "(%a = %b ⊩ %a)" pp_res r b pp_res r'
   (* | PathCondAtom (_, a) -> ff fmt "%a" pp_res a *)
   | RecordAtom entries ->
       ff fmt

--- a/program_analysis/tests/test_cases.ml
+++ b/program_analysis/tests/test_cases.ml
@@ -1,50 +1,121 @@
-let basic = [| "(fun x -> x) 1"; "(fun y -> 1 + y) 2" |]
+open Program_analysis.Solver
+
+let ri = zconst "r" isort
+let rb = zconst "r" bsort
+
+type test_case = {
+  prog : string;
+  verif : Z3.FuncDecl.func_decl -> Z3.Expr.expr;
+}
+
+let basic =
+  [|
+    {
+      prog = "(fun x -> x) 1";
+      verif = (fun p -> [ ri ] |. (p <-- [ ri ]) --> (ri === zint 1));
+    };
+    {
+      prog = "(fun y -> 1 + y) 2";
+      verif = (fun p -> [ ri ] |. (p <-- [ ri ]) --> (ri === zint 3));
+    };
+  |]
 
 let nonlocal_lookup =
   [|
-    "(fun x -> (fun y -> x + y) 2) 1";
-    "((fun x -> fun y -> x + y) 1) 2";
-    "(fun x -> (fun y -> (fun z -> x + y + z) 2) 1) 3";
+    {
+      prog = "(fun x -> (fun y -> x + y) 2) 1";
+      verif = (fun p -> [ ri ] |. (p <-- [ ri ]) --> (ri === zint 3));
+    };
+    {
+      prog = "((fun x -> fun y -> x + y) 1) 2";
+      verif = (fun p -> [ ri ] |. (p <-- [ ri ]) --> (ri === zint 3));
+    };
+    {
+      prog = "(fun x -> (fun y -> (fun z -> x + y + z) 2) 1) 3";
+      verif = (fun p -> [ ri ] |. (p <-- [ ri ]) --> (ri === zint 6));
+    };
   |]
 
 let local_stitching =
   [|
-    "let add = (fun num -> fun n -> n + num) in\n\
-     let add1 = add 1 in\n\
-     let add1' = (fun n -> add1 n) in\n\
-     add1 1 + add1' 1";
-    "let add = (fun f -> fun g -> fun x -> f g x) in\n\
-     let add1 = add (fun z -> fun n -> z n + 2) in\n\
-     let add2 = add1 (fun y -> y + 1) in\n\
-     add2 0";
+    {
+      prog =
+        "let add = (fun num -> fun n -> n + num) in\n\
+         let add1 = add 1 in\n\
+         let add1' = (fun n -> add1 n) in\n\
+         add1 1 + add1' 1";
+      verif = (fun p -> [ ri ] |. (p <-- [ ri ]) --> (ri === zint 4));
+    };
+    {
+      prog =
+        "let add = (fun f -> fun g -> fun x -> f g x) in\n\
+         let add1 = add (fun z -> fun n -> z n + 2) in\n\
+         let add2 = add1 (fun y -> y + 1) in\n\
+         add2 0";
+      verif = (fun p -> [ ri ] |. (p <-- [ ri ]) --> (ri === zint 3));
+    };
   |]
 
+(* TODO: nested ifs *)
 let conditional =
   [|
-    "(fun id -> id 10) (fun n -> if n = 0 then 0 else 1 + (n - 1))";
-    "if true then 1 else 2";
-    "(fun x -> (if true then (fun y -> y) else (fun z -> z)) x) 1";
+    {
+      prog = "(fun id -> id 10) (fun n -> if n = 0 then 0 else 1 + (n - 1))";
+      verif = (fun p -> [ ri ] |. (p <-- [ ri ]) --> (ri === zint 10));
+    };
+    {
+      prog = "if true then 1 else 2";
+      verif = (fun p -> [ ri ] |. (p <-- [ ri ]) --> (ri === zint 1));
+    };
+    {
+      prog = "(fun x -> (if true then (fun y -> y) else (fun z -> z)) x) 1";
+      verif = (fun p -> [ ri ] |. (p <-- [ ri ]) --> (ri === zint 1));
+    };
   |]
 
 let currying =
   [|
-    "let add = (fun num -> fun n -> n + num) in let add1 = add 1 in add1 2";
-    "(fun add -> (fun add1 -> (fun add2 -> add1 2) (add 2)) (add 1)) (fun num \
-     -> fun n -> n + num)";
-    "let add = (fun num -> fun n -> n + num) in let add2 = add 2 in add2 1";
-    "let add = (fun num -> fun n -> n + num) in let add1 = add 1 in let add2 = \
-     add 2 in add1 2 + add2 1";
-    "let add = (fun num -> fun n -> n + num) in\n\
-     let add1 = add 1 in\n\
-     let add2 = add 2 in\n\
-     let add3 = add 3 in\n\
-     let add4 = add 4 in\n\
-     let add5 = add 5 in\n\
-     add1 1 + add2 1 + add3 1 + add4 1 + add5 1";
+    {
+      prog =
+        "let add = (fun num -> fun n -> n + num) in let add1 = add 1 in add1 2";
+      verif = (fun p -> [ ri ] |. (p <-- [ ri ]) --> (ri === zint 3));
+    };
+    {
+      prog =
+        "(fun add -> (fun add1 -> (fun add2 -> add1 2) (add 2)) (add 1)) (fun \
+         num -> fun n -> n + num)";
+      verif = (fun p -> [ ri ] |. (p <-- [ ri ]) --> (ri === zint 3));
+    };
+    {
+      prog =
+        "let add = (fun num -> fun n -> n + num) in let add2 = add 2 in add2 1";
+      verif = (fun p -> [ ri ] |. (p <-- [ ri ]) --> (ri === zint 3));
+    };
+    {
+      prog =
+        "let add = (fun num -> fun n -> n + num) in let add1 = add 1 in let \
+         add2 = add 2 in add1 2 + add2 1";
+      verif = (fun p -> [ ri ] |. (p <-- [ ri ]) --> (ri === zint 6));
+    };
+    {
+      prog =
+        "let add = (fun num -> fun n -> n + num) in\n\
+         let add1 = add 1 in\n\
+         let add2 = add 2 in\n\
+         let add3 = add 3 in\n\
+         let add4 = add 4 in\n\
+         let add5 = add 5 in\n\
+         add1 1 + add2 1 + add3 1 + add4 1 + add5 1";
+      verif = (fun p -> [ ri ] |. (p <-- [ ri ]) --> (ri === zint 20));
+    };
   |]
 
 let recursion =
   [|
-    "let id = fun self -> fun n -> if n = 0 then 0 else 1 + self self (n - 1) \
-     in id id 10";
+    {
+      prog =
+        "let id = fun self -> fun n -> if n = 0 then 0 else 1 + self self (n - \
+         1) in id id 10";
+      verif = (fun p -> [ ri ] |. (p <-- [ ri ]) --> (ri >== zint 0));
+    };
   |]

--- a/program_analysis/tests/tests.ml
+++ b/program_analysis/tests/tests.ml
@@ -12,23 +12,26 @@ let gen_test ls =
       assert_equal expected actual)
 
 let basic_thunked =
-  [ (fun _ -> ("1", pau basic.(0))); (fun _ -> ("(1 + 2)", pau basic.(1))) ]
+  [
+    (fun _ -> ("1", pau basic.(0).prog));
+    (fun _ -> ("(1 + 2)", pau basic.(1).prog));
+  ]
 
 let test_basic _ = gen_test basic_thunked
 
 let nonlocal_lookup_thunked =
   [
-    (fun _ -> ("(1 + 2)", pau nonlocal_lookup.(0)));
-    (fun _ -> ("(1 + 2)", pau nonlocal_lookup.(1)));
-    (fun _ -> ("((3 + 1) + 2)", pau nonlocal_lookup.(2)));
+    (fun _ -> ("(1 + 2)", pau nonlocal_lookup.(0).prog));
+    (fun _ -> ("(1 + 2)", pau nonlocal_lookup.(1).prog));
+    (fun _ -> ("((3 + 1) + 2)", pau nonlocal_lookup.(2).prog));
   ]
 
 let test_nonlocal_lookup _ = gen_test nonlocal_lookup_thunked
 
 let local_stitching_thunked =
   [
-    (fun _ -> ("((1 + 1) + (1 + 1))", pau local_stitching.(0)));
-    (fun _ -> ("((0 + 1) + 2)", pau local_stitching.(1)));
+    (fun _ -> ("((1 + 1) + (1 + 1))", pau local_stitching.(0).prog));
+    (fun _ -> ("((0 + 1) + 2)", pau local_stitching.(1).prog));
   ]
 
 (* stack stitching is also needed at Var Local *)
@@ -36,22 +39,22 @@ let test_local_stitching _ = gen_test local_stitching_thunked
 
 let conditional_thunked =
   [
-    (fun _ -> ("((10 = 0) = false ⊩ (1 + (10 - 1)))", pau conditional.(0)));
-    (fun _ -> ("(true = true ⊩ 1)", pau conditional.(1)));
-    (fun _ -> ("1", pau conditional.(2)));
+    (fun _ -> ("((10 = 0) = false ⊩ (1 + (10 - 1)))", pau conditional.(0).prog));
+    (fun _ -> ("(true = true ⊩ 1)", pau conditional.(1).prog));
+    (fun _ -> ("1", pau conditional.(2).prog));
   ]
 
 let test_conditional _ = gen_test conditional_thunked
 
 let currying_thunked =
   [
-    (fun _ -> ("(2 + 1)", pau currying.(0)));
-    (fun _ -> ("(2 + 1)", pau currying.(1)));
-    (fun _ -> ("(1 + 2)", pau currying.(2)));
-    (fun _ -> ("((2 + 1) + (1 + 2))", pau currying.(3)));
+    (fun _ -> ("(2 + 1)", pau currying.(0).prog));
+    (fun _ -> ("(2 + 1)", pau currying.(1).prog));
+    (fun _ -> ("(1 + 2)", pau currying.(2).prog));
+    (fun _ -> ("((2 + 1) + (1 + 2))", pau currying.(3).prog));
     (fun _ ->
       ( "(((((1 + 1) + (1 + 2)) + (1 + 3)) + (1 + 4)) + (1 + 5))",
-        pau currying.(4) ));
+        pau currying.(4).prog ));
   ]
 
 let test_currying _ = gen_test currying_thunked
@@ -64,7 +67,7 @@ let recursion_thunked =
          1) = 0) = false ⊩ (1 + ((((10 - 1) - 1) | (((10 - 1) - 1) | (stub - \
          1) - 1) = 0) = false ⊩ (1 + stub)) | ((((10 - 1) - 1) | (((10 - 1) - \
          1) | (stub - 1) - 1) = 0) = true ⊩ 0)))))))",
-        pau recursion.(0) ));
+        pau recursion.(0).prog ));
   ]
 
 let test_recursion _ = gen_test recursion_thunked
@@ -84,12 +87,11 @@ let test_pa =
     "Church numerals" >::: test_church;
   ]
 
-let tests = "Program analysis tests" >::: test_pa
+let tests = "Program analysis tests" >::: test_pa @ Verify.verify_pa
 
 let _ =
   (* Pbt.run _; *)
   let bench = ref false in
   Arg.parse [ ("--bench", Arg.Set bench, "run benchmarks") ] (fun _ -> ()) "";
   if !bench then Bench.run tests_thunked;
-  run_test_tt_main Verify.verification;
   run_test_tt_main tests

--- a/program_analysis/tests/utils.ml
+++ b/program_analysis/tests/utils.ml
@@ -21,21 +21,47 @@ let reset_label () = label := -1
 let ( |>> ) v f = Option.map f v
 let ( |>-> ) v f = Option.bind v f
 
+(* TODO: can't use Debugutils.parse_analyze *)
 let pau s =
-  s |> Debugutils.parse_analyze |> fun (r, _) ->
-  Format.asprintf "%a" Utils.pp_res r
+  s |> Core.Fn.flip ( ^ ) ";;" |> Lexing.from_string |> Parser.main Lexer.token
+  |> Lib.analyze ~debug:false
+  |> Format.asprintf "%a" Utils.pp_res
 
-let pau' s = s |> Debugutils.parse_analyze |> snd
+let pau' ?(entry = "P0") s =
+  s |> Core.Fn.flip ( ^ ) ";;" |> Lexing.from_string |> Parser.main Lexer.token
+  |> Lib.analyze ~debug:false
+  |> fun r ->
+  (* pf "result: %a\n" Grammar.pp_res r; *)
+  Solver.chcs_of_res r ~entry;
+  let chcs = Solver.list_of_chcs () in
 
-let verify_result chcs assns =
+  (* Format.printf "CHCs:\n";
+     List.iter ~f:(fun chc -> Format.printf "%s\n" (Z3.Expr.to_string chc)) chcs; *)
+  let entry = Option.get !Solver.entry_decl in
+
+  (* pf "\nres_to_id:\n";
+     Core.Hashtbl.iteri
+       ~f:(fun ~key ~data ->
+         Format.printf "key: %a\ndata: %d\n" Grammar.pp_res key data)
+       Solver.res_to_id;
+
+     pf "atom_to_id:\n";
+     Core.Hashtbl.iteri
+       ~f:(fun ~key ~data ->
+         Format.printf "key: %a\ndata: %d\n" Grammar.pp_atom key data)
+       Solver.atom_to_id; *)
+  Solver.reset ();
+  (chcs, entry)
+
+let verify_result chcs =
   let solver = Solver.solver in
   Z3.Solver.add solver chcs;
-  match Z3.Solver.check solver assns with
+  match Z3.Solver.check solver [] with
   | SATISFIABLE ->
       pf "\nsat\n\n";
       let model = solver |> Z3.Solver.get_model |> Core.Option.value_exn in
       model |> Z3.Model.to_string |> pf "Model:\n%s\n\n";
-      (* solver |> Z3.Solver.to_string |> pf "Solver:\n%s"; *)
+      solver |> Z3.Solver.to_string |> pf "Solver:\n%s";
       true
   | UNSATISFIABLE ->
       pf "unsat";

--- a/program_analysis/tests/verify.ml
+++ b/program_analysis/tests/verify.ml
@@ -1,32 +1,44 @@
+[@@@warning "-26"]
+
 open OUnit2
 open Utils
+open Program_analysis
+open Solver
 
-let failed = "FAILED TO VERIFY"
+let msg = "FAILED TO VERIFY"
 
 let verify_basic _ =
   let test = Test_cases.basic.(0) in
-  pf "\nTest 0: %s\n" test;
-  assert_bool failed (verify_result (pau' test) []);
+  pf "\nTest 1: %s\n" test;
+  let chcs, p = pau' test in
+  let r = zconst "r" isort in
+  let verif = [ r ] |. (p <-- [ r ]) --> (r === zint 1) in
+  assert_bool msg (verify_result (verif :: chcs));
 
   let test = Test_cases.basic.(1) in
-  pf "\nTest 1: %s\n" test;
-  assert_bool failed (verify_result (pau' test) [])
+  pf "\nTest 2: %s\n" test;
+  let chcs, p = pau' test in
+  let r = zconst "r" isort in
+  let verif = [ r ] |. (p <-- [ r ]) --> (r === zint 3) in
+  assert_bool msg (verify_result (verif :: chcs))
 
 let verify_conditional _ =
   let test = Test_cases.conditional.(1) in
   pf "\nTest 3: %s\n" test;
-  assert_bool failed (verify_result (pau' test) [])
+  let chcs, p = pau' test in
+  assert_bool msg (verify_result chcs)
 
 let verify_recursion _ =
   let test = Test_cases.recursion.(0) in
   pf "\nTest 4: %s\n" test;
-  assert_bool failed (verify_result (pau' test) [])
+  let chcs, p = pau' test in
+  let r = zconst "r" isort in
+  let verif = [ r ] |. (p <-- [ r ]) --> (r >== zint 0) in
+  assert_bool msg (verify_result (verif :: chcs))
 
 let verify_pa =
-  [
-    "Verify basic" >:: verify_basic;
-    "Verify conditional" >:: verify_conditional;
-    "Verify recursion" >:: verify_recursion;
-  ]
+  [ (* "Verify basic" >:: verify_basic; *)
+    (* "Verify conditional" >:: verify_conditional; *)
+    (* "Verify recursion" >:: verify_recursion; *) ]
 
 let verification = "Program analysis verification tests" >::: verify_pa

--- a/program_analysis/tests/verify.ml
+++ b/program_analysis/tests/verify.ml
@@ -7,18 +7,35 @@ let verify_basic _ =
   verify_result Test_cases.basic.(0);
   verify_result Test_cases.basic.(1)
 
+let verify_nonlocal_lookup _ =
+  verify_result Test_cases.nonlocal_lookup.(0);
+  verify_result Test_cases.nonlocal_lookup.(1);
+  verify_result Test_cases.nonlocal_lookup.(2)
+
+let verify_local_stitching _ =
+  verify_result Test_cases.local_stitching.(0);
+  verify_result Test_cases.local_stitching.(1)
+
 let verify_conditional _ =
   verify_result Test_cases.conditional.(0);
   verify_result Test_cases.conditional.(1);
   verify_result Test_cases.conditional.(2)
+
+let verify_currying _ =
+  verify_result Test_cases.currying.(0);
+  verify_result Test_cases.currying.(1);
+  verify_result Test_cases.currying.(2);
+  verify_result Test_cases.currying.(3);
+  verify_result Test_cases.currying.(4)
 
 let verify_recursion _ = verify_result Test_cases.recursion.(0)
 
 let verify_pa =
   [
     "Verify basic" >:: verify_basic;
+    "Verify non-local lookup" >:: verify_nonlocal_lookup;
+    "Verify local stitching" >:: verify_local_stitching;
     "Verify conditional" >:: verify_conditional;
+    "Verify currying" >:: verify_currying;
     "Verify recursion" >:: verify_recursion;
   ]
-
-let verification = "Program analysis verification tests" >::: verify_pa

--- a/program_analysis/tests/verify.ml
+++ b/program_analysis/tests/verify.ml
@@ -1,44 +1,24 @@
-[@@@warning "-26"]
-
 open OUnit2
-open Utils
-open Program_analysis
-open Solver
 
 let msg = "FAILED TO VERIFY"
+let verify_result test = assert_bool msg (Utils.verify_result test)
 
 let verify_basic _ =
-  let test = Test_cases.basic.(0) in
-  pf "\nTest 1: %s\n" test;
-  let chcs, p = pau' test in
-  let r = zconst "r" isort in
-  let verif = [ r ] |. (p <-- [ r ]) --> (r === zint 1) in
-  assert_bool msg (verify_result (verif :: chcs));
-
-  let test = Test_cases.basic.(1) in
-  pf "\nTest 2: %s\n" test;
-  let chcs, p = pau' test in
-  let r = zconst "r" isort in
-  let verif = [ r ] |. (p <-- [ r ]) --> (r === zint 3) in
-  assert_bool msg (verify_result (verif :: chcs))
+  verify_result Test_cases.basic.(0);
+  verify_result Test_cases.basic.(1)
 
 let verify_conditional _ =
-  let test = Test_cases.conditional.(1) in
-  pf "\nTest 3: %s\n" test;
-  let chcs, p = pau' test in
-  assert_bool msg (verify_result chcs)
+  verify_result Test_cases.conditional.(0);
+  verify_result Test_cases.conditional.(1);
+  verify_result Test_cases.conditional.(2)
 
-let verify_recursion _ =
-  let test = Test_cases.recursion.(0) in
-  pf "\nTest 4: %s\n" test;
-  let chcs, p = pau' test in
-  let r = zconst "r" isort in
-  let verif = [ r ] |. (p <-- [ r ]) --> (r >== zint 0) in
-  assert_bool msg (verify_result (verif :: chcs))
+let verify_recursion _ = verify_result Test_cases.recursion.(0)
 
 let verify_pa =
-  [ (* "Verify basic" >:: verify_basic; *)
-    (* "Verify conditional" >:: verify_conditional; *)
-    (* "Verify recursion" >:: verify_recursion; *) ]
+  [
+    "Verify basic" >:: verify_basic;
+    "Verify conditional" >:: verify_conditional;
+    "Verify recursion" >:: verify_recursion;
+  ]
 
 let verification = "Program analysis verification tests" >::: verify_pa


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #88

Fix a small but critical bug that caused bad implications in the
generated CHCs (correlating unrelated predicates) - not clearing one of
the two hash tables used to track prediate IDs between runs.

Add and apply verifying assertions for all existing test cases.

Test plan:

`dune test program_analysis` and all tests pass.