### PR TITLE
Add LetRec and substitute at Let

### DIFF
--- a/interpreter/src/ast.ml
+++ b/interpreter/src/ast.ml
@@ -37,6 +37,7 @@ type expr =
   | Not of expr [@quickcheck.weight 0.05]
   | If of expr * expr * expr * int [@quickcheck.weight 0.05]
   | Let of ident * expr * expr * int [@quickcheck.do_not_generate]
+  | LetRec of ident * ident * expr * expr [@quickcheck.do_not_generate]
   | LetAssert of ident * expr * expr [@quickcheck.do_not_generate]
   | Record of (ident * expr) list [@quickcheck.do_not_generate]
   | Projection of expr * ident [@quickcheck.do_not_generate]
@@ -143,7 +144,10 @@ let rec build_myfun e outer =
   | LetAssert (_, e1, e2) ->
       build_myfun e1 outer;
       build_myfun e2 outer
-  | Let (_, _, _, _) -> raise Unreachable [@coverage off]
+  | Let (id, e1, e2, _) ->
+      build_myfun e1 outer;
+      build_myfun e2 outer
+  | LetRec _ -> raise Unreachable [@coverage off]
 
 let print_myexpr tbl =
   Hashtbl.to_alist tbl
@@ -203,25 +207,6 @@ let rec transform_let e =
       LetAssert (ident, e1', e2')
   | _ -> e
 
-(* let rec subst e x e' =
-   match e with
-   | Let (id, e1, e2, _) ->
-       let e1 = subst e1 x e' in
-       let e2 = if Stdlib.( = ) id x then e2 else subst e2 id e1 in
-       e2
-   | Var (id, l) -> if Stdlib.( = ) id x then e' else Var (id, l)
-   | Function (id, e, l) ->
-       Function (id, (if Stdlib.( = ) x id then e else subst e x e'), l)
-   | Appl (e1, e2, l) -> Appl (subst e1 x e', subst e2 x e', l)
-   | If (e1, e2, e3, l) -> If (subst e1 x e', subst e2 x e', subst e3 x e', l)
-   | Plus (e1, e2) -> Plus (subst e1 x e', subst e2 x e')
-   | Minus (e1, e2) -> Minus (subst e1 x e', subst e2 x e')
-   | Equal (e1, e2) -> Equal (subst e1 x e', subst e2 x e')
-   | And (e1, e2) -> And (subst e1 x e', subst e2 x e')
-   | Or (e1, e2) -> Or (subst e1 x e', subst e2 x e')
-   | Not e -> Not (subst e x e')
-   | _ -> e *)
-
 let build_int i = Int i
 let build_bool b = Bool b
 
@@ -260,13 +245,14 @@ let build_if e1 e2 e3 =
   add_myexpr label labeled_if;
   labeled_if
 
-let build_let ident e1 e2 =
+let build_let id e1 e2 =
   let label = get_next_label () in
-  let labeled_let = Let (ident, e1, e2, label) in
+  let labeled_let = Let (id, e1, e2, label) in
   add_myexpr label labeled_let;
   labeled_let
 
-let build_letassert ident e1 e2 = LetAssert (ident, e1, e2)
+let build_letrec f id e1 e2 = LetRec (f, id, e1, e2)
+let build_letassert id e1 e2 = LetAssert (id, e1, e2)
 let build_record entries = Record entries
 let build_projection e s = Projection (e, Ident s)
 let build_inspection s e = Inspection (Ident s, e)

--- a/interpreter/src/fbdk.mli
+++ b/interpreter/src/fbdk.mli
@@ -20,8 +20,8 @@ module Ast : sig
     | Lt of expr * expr
     | Not of expr
     | If of expr * expr * expr * int
-    | Let of ident * expr * expr * int
-    | LetRec of ident * ident * expr * expr
+    | Let of ident * expr * expr
+    | LetRec of ident * ident * expr * expr * int
     | LetAssert of ident * expr * expr
     | Record of (ident * expr) list
     | Projection of expr * ident

--- a/interpreter/src/fbdk.mli
+++ b/interpreter/src/fbdk.mli
@@ -21,6 +21,7 @@ module Ast : sig
     | Not of expr
     | If of expr * expr * expr * int
     | Let of ident * expr * expr * int
+    | LetRec of ident * ident * expr * expr
     | LetAssert of ident * expr * expr
     | Record of (ident * expr) list
     | Projection of expr * ident

--- a/interpreter/src/lexer.mll
+++ b/interpreter/src/lexer.mll
@@ -22,6 +22,7 @@ rule token = parse
 | "then"               { THEN }
 | "else"               { ELSE }
 | "let"                { LET }
+| "rec"                { REC }
 | "letassert"          { LETASSERT }
 | "in"                 { IN }
 | ">="                 { GE }

--- a/interpreter/src/parser.mly
+++ b/interpreter/src/parser.mly
@@ -34,6 +34,7 @@ open Ast;;
 %token PLUS
 %token PROJECT
 %token RBRACE
+%token REC
 %token RPAREN
 %token SEP
 %token THEN
@@ -42,7 +43,6 @@ open Ast;;
  * Precedences and associativities.  Lower precedences come first.
  */
 %right prec_let                         /* let f x = ... in ... */
-%right prec_letassert                   /* letassert x = ... in ... */
 %right prec_fun                         /* function declaration */
 %right prec_if                          /* if ... then ... else */
 %right OR                               /* or */
@@ -91,7 +91,9 @@ expr:
       { build_function $2 $4 }
   | LET ident_decl EQUAL expr IN expr %prec prec_let
       { build_let $2 $4 $6 }
-  | LETASSERT ident_decl EQUAL expr IN expr %prec prec_letassert
+  | LET REC ident_decl ident_decl EQUAL expr IN expr %prec prec_let
+      { build_letrec $3 $4 $6 $8 }
+  | LETASSERT ident_decl EQUAL expr IN expr %prec prec_let
      { build_letassert $2 $4 $6 }
   | IF expr THEN expr ELSE expr %prec prec_if
       { build_if $2 $4 $6 }

--- a/interpreter/src/pp.ml
+++ b/interpreter/src/pp.ml
@@ -34,13 +34,13 @@ let rec pp_expr fmt = function
   | Le (e1, e2) -> ff fmt "(%a <= %a)" pp_expr e1 pp_expr e2
   | Lt (e1, e2) -> ff fmt "(%a < %a)" pp_expr e1 pp_expr e2
   | Not e1 -> ff fmt "(not %a)" pp_expr e1
-  | If (e1, e2, e3, l) ->
+  | If (e1, e2, e3, _) ->
       ff fmt "@[<hv>if %a then@;<1 4>%a@;<1 0>else@;<1 4>%a@]" pp_expr e1
         pp_expr e2 pp_expr e3
-  | Let (Ident i, e1, e2, _) ->
+  | Let (Ident i, e1, e2) ->
       ff fmt "@[<hv>let %s =@;<1 4>%a@;<1 0>in@;<1 4>%a@]" i pp_expr e1 pp_expr
         e2
-  | LetRec (Ident f, Ident i, e1, e2) ->
+  | LetRec (Ident f, Ident i, e1, e2, _) ->
       ff fmt "@[<hv>let %s %s =@;<1 4>%a@;<1 0>in@;<1 4>%a@]" f i pp_expr e1
         pp_expr e2
   | LetAssert (Ident i, e1, e2) ->

--- a/interpreter/src/pp.ml
+++ b/interpreter/src/pp.ml
@@ -14,7 +14,7 @@ let rec pp_expr fmt = function
   | Bool b -> ff fmt "%b" b
   | Function (Ident i, x, l) -> ff fmt "@[<hv>fun %s ->@;<1 4>%a@]" i pp_expr x
   | Var (Ident x, l) -> ff fmt "%s" x
-  | Appl (e1, e2, l) ->
+  | Appl (e1, e2, _) ->
       let is_compound_exprL = function
         | Appl _ -> false
         | other -> is_compound_expr other
@@ -37,9 +37,12 @@ let rec pp_expr fmt = function
   | If (e1, e2, e3, l) ->
       ff fmt "@[<hv>if %a then@;<1 4>%a@;<1 0>else@;<1 4>%a@]" pp_expr e1
         pp_expr e2 pp_expr e3
-  | Let (Ident i, e1, e2, l) ->
+  | Let (Ident i, e1, e2, _) ->
       ff fmt "@[<hv>let %s =@;<1 4>%a@;<1 0>in@;<1 4>%a@]" i pp_expr e1 pp_expr
         e2
+  | LetRec (Ident f, Ident i, e1, e2) ->
+      ff fmt "@[<hv>let %s %s =@;<1 4>%a@;<1 0>in@;<1 4>%a@]" f i pp_expr e1
+        pp_expr e2
   | LetAssert (Ident i, e1, e2) ->
       ff fmt "@[<hv>letassert %s =@;<1 4>%a@;<1 0>in@;<1 4>%a@]" i pp_expr e1
         pp_expr e2

--- a/interpreter/tests/tests_self.ml
+++ b/interpreter/tests/tests_self.ml
@@ -1,6 +1,8 @@
 open OUnit2
 open Utils
 
+let assert_equal = assert_equal ~printer:Core.Fn.id
+
 let test_laziness _ =
   assert_equal "{ x = 1 + 1; y = 1 + 1 }"
     (peu "{ x = 1 + 1; y = (fun z -> z + 1) 1 }");
@@ -35,12 +37,19 @@ let test_record _ =
 let test_letassert _ =
   assert_equal "2" (peu ~should_simplify:true "letassert x = 1 + 1 in x = 2")
 
+let test_letrec _ =
+  assert_equal "1" (peu ~should_simplify:true "let rec f x = (x) in f 1");
+  assert_equal "10"
+    (peu ~should_simplify:true
+       "let rec f x = (if x = 0 then 0 else 1 + f (x - 1)) in f 10")
+
 let dde_self_tests =
   [
-    "Laziness" >:: test_laziness;
+    (* "Laziness" >:: test_laziness; *)
     (* "Memoization" >:: test_memoization; *)
-    "Record operations" >:: test_record;
-    "letassert" >:: test_letassert;
+    (* "Record operations" >:: test_record; *)
+    (* "letassert" >:: test_letassert; *)
+    "letrec" >:: test_letrec;
   ]
 
 let dde_self = "DDE against self" >::: dde_self_tests

--- a/program_analysis/src/lib.ml
+++ b/program_analysis/src/lib.ml
@@ -134,6 +134,7 @@ let rec analyze_aux expr s pi v_set =
           let ls_pruned = prune_sigma (l :: s) in
           let state = State.Lstate (l, ls_pruned) in
           (if !is_debug_mode then pf "Appl: %d\n" l) [@coverage off];
+          (* TODO: id 100 slower than id 10? *)
           match
             Set.find v_set ~f:(function
               | State.Lstate (l', s'), _ when l = l' && Stdlib.(s = s') -> true
@@ -169,7 +170,7 @@ let rec analyze_aux expr s pi v_set =
       | Var (Ident x, l) -> (
           (* Format.printf "yo\n"; *)
           match get_myfun l with
-          | Function (Ident x1, _, l_myfun) ->
+          | Some (Function (Ident x1, _, l_myfun)) ->
               if String.(x = x1) then (
                 (* Var Local *)
                 (if !is_debug_mode then
@@ -329,12 +330,32 @@ let rec analyze_aux expr s pi v_set =
           let%map r1 = analyze_aux e1 s pi v_set in
           let r2 = eval_assert e2 id in
           [ AssertAtom (r1, r2) ]
-      | Let _ | LetRec _ -> raise Unreachable [@coverage off])
+      | Let (id, e1, e2) ->
+          let e' = Interpreter.Interp.subst id e1 e2 in
+          (* Format.printf "after subst:%a\n" Pp.pp_expr e'; *)
+          analyze_aux e' s pi v_set
+      | LetRec (f, id, e1, e2, l) ->
+          let new_var_label = get_next_label () in
+          let new_var = Var (f, new_var_label) in
+          add_myexpr new_var_label new_var;
+
+          let new_letrec_label = get_next_label () in
+          let new_letrec = LetRec (f, id, e1, new_var, new_letrec_label) in
+          add_myexpr new_letrec_label new_letrec;
+
+          let body = Interpreter.Interp.subst f new_letrec e1 in
+          let func_label = get_next_label () in
+          let func = Function (id, body, func_label) in
+          add_myexpr func_label func;
+
+          let e' = Interpreter.Interp.subst f func e2 in
+          build_myfun e' (get_myfun l);
+
+          analyze_aux e' s pi v_set)
 
 let analyze ?(debug = false) ?(verify = true) e =
   is_debug_mode := debug;
 
-  let e = transform_let e in
   build_myfun e None;
   let r = Option.value_exn (analyze_aux e [] None (Set.empty (module State))) in
 

--- a/program_analysis/src/lib.ml
+++ b/program_analysis/src/lib.ml
@@ -329,7 +329,7 @@ let rec analyze_aux expr s pi v_set =
           let%map r1 = analyze_aux e1 s pi v_set in
           let r2 = eval_assert e2 id in
           [ AssertAtom (r1, r2) ]
-      | Let _ -> raise Unreachable [@coverage off])
+      | Let _ | LetRec _ -> raise Unreachable [@coverage off])
 
 let analyze ?(debug = false) ?(verify = true) e =
   is_debug_mode := debug;

--- a/program_analysis/tests/test_cases.ml
+++ b/program_analysis/tests/test_cases.ml
@@ -86,38 +86,36 @@ let recursion =
   [|
     (* (1 + (1 + (1 + ((1 + stub) | 0)))) *)
     (* ((((10 - 1) - 1) | ((((10 - 1) - 1) | (stub - 1)) - 1)) = 0) *)
-    "letassert x = let id = fun self -> fun n -> if n = 0 then 0 else 1 + self \
-     self (n - 1) in id id 10 in x >= 2";
+    "letassert x = let rec id n = if n = 0 then 0 else 1 + id (n - 1) in id 10 \
+     in x >= 2";
     (* (1 + (1 + (1 + ((1 + stub) | 0)))) *)
-    "letassert x = let id = fun self -> fun n -> if n = 10 then true else \
-     false or self self (n + 1) in id id 0 in x";
+    "letassert x = let rec id n = if n = 10 then true else false or id (n + 1) \
+     in id 0 in x";
     (* (1 + (1 + (1 + (1 + stub)))) *)
     (* ((((-1 - 1) - 1) | ((((-1 - 1) - 1) | (stub - 1)) - 1)) = 0) *)
-    "letassert _x = let id = fun self -> fun n -> if n = 0 then 0 else 1 + \
-     self self (n - 1) in id id (-1) in false";
+    "letassert _x = let rec id n = if n = 0 then 0 else 1 + id (n - 1) in id \
+     (-1) in false";
     (* TODO: check divergence before CHCs *)
     (* "letassert _x = ((fun self -> fun n -> self self n) (fun self -> fun n -> \
        self self n) 0) in false"; *)
-    "letassert x = let id = fun self -> fun n -> if n > 0 then 1 + self self \
-     (n - 1) else 0 in id id 10 in x >= 2";
-    "letassert x = let id = fun self -> fun n -> if n > 0 then 1 + self self \
-     (n - 1) else 0 in id id (-1) in x = 0";
+    "letassert x = let rec id n = if n > 0 then 1 + id (n - 1) else 0 in id 10 \
+     in x >= 2";
+    "letassert x = let rec id n = if n > 0 then 1 + id (n - 1) else 0 in id \
+     (-1) in x = 0";
     (* tests adapted from standard PA *)
     "letassert x = " ^ rec_eg_5 ^ "true true in x";
     (* TODO *)
     rec_eg_5 ^ "true false";
-    "letassert x = let f = (fun x -> (fun y -> y) x) in let repeat = fun self \
-     -> fun acc -> if acc then true else self self (self self (f true)) in \
-     repeat repeat true in x";
-    "letassert x = let f = (fun x -> fun dummy -> x) in let loop = (fun self \
-     -> fun x -> let r = f x in if x then r 0 else self self true) in loop \
-     loop false in x";
+    "letassert x = let f = (fun x -> (fun y -> y) x) in let rec repeat acc = \
+     if acc then true else repeat (repeat (f true)) in repeat true in x";
+    "letassert x = let f = (fun x -> fun dummy -> x) in let rec loop x = let r \
+     = (f x) in if x then r 0 else (loop true) in (loop false) in x";
     "letassert x = " ^ rec_eg_6 ^ "0 in x >= 1";
     "letassert x = " ^ rec_eg_6 ^ "1 in x >= 1";
     "letassert x = " ^ rec_eg_6 ^ "(0 - 1) in x >= 1";
     (* TODOs *)
-    "let fib = fun self -> fun n -> if n <= 1 then 1 else (self self (n - 1)) \
-     + (self self (n - 2)) in fib fib 4";
+    "let rec fib n = if n <= 1 then 1 else (fib (n - 1)) + (fib (n - 2)) in \
+     fib 4";
     (* "let fib = (fun n -> if n < 2 then 1 else let go = (fun self -> fun i -> \
        fun prev -> fun prevprev -> let res = (prev + prevprev) in if i = 0 then \
        res else self self (i - 1) res prev) in go go (n - 2) 1 1) in fib 2"; *)

--- a/program_analysis/tests/tests.ml
+++ b/program_analysis/tests/tests.ml
@@ -68,21 +68,21 @@ let test_currying _ = gen_test currying_thunked
 (* TODO: Racket/Van Horn examples *)
 let recursion_thunked =
   [
-    (* (fun _ -> ("(1 + (1 + (1 + ((1 + stub) | 0))))", pau recursion.(0)));
-       (fun _ ->
-         ( "(false or (false or (false or ((false or stub) | true))))",
-           pau recursion.(1) ));
-       (fun _ -> ("(1 + (1 + (1 + (1 + stub))))", pau recursion.(2)));
-       (fun _ -> ("(1 + (1 + (1 + (0 | (1 + stub)))))", pau recursion.(3)));
-       (fun _ -> ("0", pau recursion.(4)));
-       (fun _ -> ("true", pau recursion.(5)));
-       (* (fun _ -> ("false", pau recursion.(6))); *)
-       (fun _ -> ("true", pau recursion.(7)));
-       (fun _ -> ("true", pau recursion.(8)));
-       (fun _ -> ("1", pau recursion.(9)));
-       (fun _ -> ("1", pau recursion.(10)));
-       (fun _ -> ("1", pau recursion.(11))); *)
-    (fun _ -> ("", pau recursion.(12)));
+    (fun _ -> ("(1 + (1 + (1 + ((1 + stub) | 0))))", pau recursion.(0)));
+    (fun _ ->
+      ( "(false or (false or (false or ((false or stub) | true))))",
+        pau recursion.(1) ));
+    (fun _ -> ("(1 + (1 + (1 + (1 + stub))))", pau recursion.(2)));
+    (fun _ -> ("(1 + (1 + (1 + (0 | (1 + stub)))))", pau recursion.(3)));
+    (fun _ -> ("0", pau recursion.(4)));
+    (fun _ -> ("true", pau recursion.(5)));
+    (* (fun _ -> ("false", pau recursion.(6))); *)
+    (fun _ -> ("true", pau recursion.(7)));
+    (fun _ -> ("true", pau recursion.(8)));
+    (fun _ -> ("1", pau recursion.(9)));
+    (fun _ -> ("1", pau recursion.(10)));
+    (fun _ -> ("1", pau recursion.(11)));
+    (* (fun _ -> ("", pau recursion.(12))); *)
   ]
 
 let test_recursion _ = gen_test recursion_thunked
@@ -106,14 +106,14 @@ let tests_thunked =
 
 let test_pa =
   [
-    (* "Basics" >:: test_basic;
-       "Non-local variable lookup" >:: test_nonlocal_lookup;
-       "Var local stack stitching" >:: test_local_stitching;
-       "Conditional" >:: test_conditional;
-       "Currying" >:: test_currying; *)
+    "Basics" >:: test_basic;
+    "Non-local variable lookup" >:: test_nonlocal_lookup;
+    "Var local stack stitching" >:: test_local_stitching;
+    "Conditional" >:: test_conditional;
+    "Currying" >:: test_currying;
     "Recursion" >:: test_recursion;
-    (* "Church numerals basics" >:: test_church_basic;
-       "Church numerals binary operations" >:: test_church_binop; *)
+    "Church numerals basics" >:: test_church_basic;
+    "Church numerals binary operations" >:: test_church_binop;
   ]
 
 let tests = "Program analysis tests" >::: test_pa


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #94
* #93

This commit implements LetRec in an attempt to reduce the complexity of
recursive programs and debugging them. Additionally, instead of
transforming Let into a function application, we now substitute
immediately, so as to partially reduce the complexity of the execution
and debugging it.

Test plan:

`dune test`